### PR TITLE
Add detailed plant and room views with dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.ico" />
       </head>
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`}>{children}</body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,13 +9,14 @@ type Plant = {
   species: string
   status: string
   hydration: number
+  note?: string
 }
 
 const plants: Plant[] = [
-  { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72 },
-  { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90 },
-  { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70 },
-  { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75 },
+  { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72, note: "Needs water" },
+  { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90, note: "Loves bright light" },
+  { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70, note: "Trailing nicely" },
+  { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75, note: "New growth" },
 ]
 
 export default function TodayPage() {
@@ -34,6 +35,7 @@ export default function TodayPage() {
               species={p.species}
               status={p.status}
               hydration={p.hydration}
+              note={p.note}
             />
           </Link>
         ))}

--- a/app/plants/[id]/page.tsx
+++ b/app/plants/[id]/page.tsx
@@ -3,10 +3,55 @@ import SidebarNav from "@/components/SidebarNav"
 import Header from "@/components/Header"
 
 const samplePlants = {
-  "1": { nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72 },
-  "2": { nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90 },
-  "3": { nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70 },
-  "4": { nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75 },
+  "1": {
+    nickname: "Delilah",
+    species: "Monstera deliciosa",
+    status: "Water overdue",
+    hydration: 72,
+    lastWatered: "Aug 25",
+    nextDue: "Aug 30",
+    events: [
+      { id: 1, type: "water", date: "Aug 25" },
+      { id: 2, type: "note", date: "Aug 20", note: "New leaf unfurling" }
+    ],
+    photos: [
+      "https://placehold.co/800x400?text=Delilah",
+      "https://placehold.co/300x300?text=Delilah"
+    ]
+  },
+  "2": {
+    nickname: "Sunny",
+    species: "Sansevieria trifasciata",
+    status: "Fine",
+    hydration: 90,
+    lastWatered: "Aug 27",
+    nextDue: "Sep 5",
+    events: [{ id: 1, type: "water", date: "Aug 27" }],
+    photos: ["https://placehold.co/800x400?text=Sunny"]
+  },
+  "3": {
+    nickname: "Ivy",
+    species: "Epipremnum aureum",
+    status: "Due today",
+    hydration: 70,
+    lastWatered: "Aug 28",
+    nextDue: "Aug 29",
+    events: [{ id: 1, type: "water", date: "Aug 28" }],
+    photos: ["https://placehold.co/800x400?text=Ivy"]
+  },
+  "4": {
+    nickname: "Figgy",
+    species: "Ficus lyrata",
+    status: "Fertilize suggested",
+    hydration: 75,
+    lastWatered: "Aug 23",
+    nextDue: "Sep 2",
+    events: [
+      { id: 1, type: "fertilize", date: "Aug 15" },
+      { id: 2, type: "water", date: "Aug 23" }
+    ],
+    photos: ["https://placehold.co/800x400?text=Figgy"]
+  }
 }
 
 export default function PlantDetailPage({ params }: { params: { id: string } }) {
@@ -14,41 +59,70 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-56 border-r bg-gray-50">
+      <aside className="w-56 border-r bg-gray-50 dark:bg-gray-900 dark:border-gray-700">
         <SidebarNav />
       </aside>
-      <main className="flex-1">
+      <main className="flex-1 bg-white dark:bg-gray-900">
         <Header />
 
-        <div className="p-6 space-y-4">
-          <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50">
+        <div className="p-6 space-y-6">
+          <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
             ← Back to Today
           </Link>
 
           {!plant ? (
-            <div className="rounded-lg border p-6">
+            <div className="rounded-lg border p-6 dark:border-gray-700">
               <h2 className="text-xl font-bold">Plant not found</h2>
               <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
             </div>
           ) : (
             <>
+              <img
+                src={plant.photos[0]}
+                alt={plant.nickname}
+                className="w-full max-h-64 object-cover rounded-lg border dark:border-gray-700"
+              />
               <header>
                 <h1 className="text-2xl font-bold">{plant.nickname}</h1>
                 <p className="italic text-gray-500">{plant.species}</p>
               </header>
 
               <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="rounded-lg border p-4">
+                <div className="rounded-lg border p-4 dark:border-gray-700">
                   <p className="font-medium">Status</p>
-                  <p className="text-gray-700">{plant.status}</p>
+                  <p className="text-gray-700 dark:text-gray-300">{plant.status}</p>
                 </div>
-                <div className="rounded-lg border p-4">
+                <div className="rounded-lg border p-4 dark:border-gray-700">
                   <p className="font-medium">Hydration</p>
-                  <p className="text-gray-700">{plant.hydration}%</p>
+                  <p className="text-gray-700 dark:text-gray-300">{plant.hydration}%</p>
                 </div>
-                <div className="rounded-lg border p-4">
-                  <p className="font-medium">Next Task</p>
-                  <p className="text-gray-700">Water in ~2 days</p>
+                <div className="rounded-lg border p-4 dark:border-gray-700">
+                  <p className="font-medium">Last Watered</p>
+                  <p className="text-gray-700 dark:text-gray-300">{plant.lastWatered}</p>
+                </div>
+                <div className="rounded-lg border p-4 dark:border-gray-700">
+                  <p className="font-medium">Next Due</p>
+                  <p className="text-gray-700 dark:text-gray-300">{plant.nextDue}</p>
+                </div>
+              </section>
+
+              <section>
+                <h2 className="font-semibold mb-2">Timeline</h2>
+                <ul className="space-y-2 text-sm">
+                  {plant.events.map((e) => (
+                    <li key={e.id} className="rounded border p-2 dark:border-gray-700">
+                      {e.date}: {e.type === "note" ? e.note : e.type === "water" ? "Watered" : "Fertilized"}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section>
+                <h2 className="font-semibold mb-2">Gallery</h2>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                  {plant.photos.map((src, i) => (
+                    <img key={i} src={src} alt={`${plant.nickname} photo ${i + 1}`} className="rounded-lg border dark:border-gray-700" />
+                  ))}
                 </div>
               </section>
             </>

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -1,11 +1,34 @@
 import Link from "next/link"
 import SidebarNav from "@/components/SidebarNav"
 import Header from "@/components/Header"
+import PlantCard from "@/components/PlantCard"
 
 const sampleRooms = {
-  "living-room": { name: "Living Room", hydration: 72, tasks: 2 },
-  "bedroom": { name: "Bedroom", hydration: 65, tasks: 1 },
-  "office": { name: "Office", hydration: 82, tasks: 0 },
+  "living-room": {
+    name: "Living Room",
+    hydration: 72,
+    tasks: 2,
+    plants: [
+      { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72 },
+      { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70 }
+    ]
+  },
+  "bedroom": {
+    name: "Bedroom",
+    hydration: 65,
+    tasks: 1,
+    plants: [
+      { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90 }
+    ]
+  },
+  "office": {
+    name: "Office",
+    hydration: 82,
+    tasks: 0,
+    plants: [
+      { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75 }
+    ]
+  }
 }
 
 export default function RoomDetailPage({ params }: { params: { id: string } }) {
@@ -13,19 +36,19 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-56 border-r bg-gray-50">
+      <aside className="w-56 border-r bg-gray-50 dark:bg-gray-900 dark:border-gray-700">
         <SidebarNav />
       </aside>
-      <main className="flex-1">
+      <main className="flex-1 bg-white dark:bg-gray-900">
         <Header />
 
-        <div className="p-6 space-y-4">
-          <Link href="/rooms" className="inline-block px-3 py-1 border rounded hover:bg-gray-50">
+        <div className="p-6 space-y-6">
+          <Link href="/rooms" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
             ← Back to Rooms
           </Link>
 
           {!room ? (
-            <div className="rounded-lg border p-6">
+            <div className="rounded-lg border p-6 dark:border-gray-700">
               <h2 className="text-xl font-bold">Room not found</h2>
               <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
             </div>
@@ -37,14 +60,14 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
                 <p className="text-gray-500">{room.tasks} tasks due</p>
               </header>
 
-              <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="rounded-lg border p-4">
-                  <p className="font-medium">Recent Activity</p>
-                  <p className="text-gray-700">Watered two plants yesterday</p>
-                </div>
-                <div className="rounded-lg border p-4">
-                  <p className="font-medium">Environment</p>
-                  <p className="text-gray-700">North window · Bright indirect</p>
+              <section>
+                <h2 className="font-semibold mb-2">Plants</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {room.plants.map((p) => (
+                    <Link key={p.id} href={`/plants/${p.id}`} className="block">
+                      <PlantCard nickname={p.nickname} species={p.species} status={p.status} hydration={p.hydration} />
+                    </Link>
+                  ))}
                 </div>
               </section>
             </>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,15 +1,20 @@
 "use client"
 import { PlusCircle, Sun, Moon } from "lucide-react"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 export default function Header() {
   const [dark, setDark] = useState(false)
 
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.toggle("dark", dark)
+  }, [dark])
+
   return (
-    <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
+    <header className="backdrop-blur bg-white/80 dark:bg-gray-900/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
       <div>
-        <p className="text-sm text-gray-600">Friday, Aug 29</p>
-        <p className="font-medium">
+        <p className="text-sm text-gray-600 dark:text-gray-400">Friday, Aug 29</p>
+        <p className="font-medium text-gray-800 dark:text-gray-100">
           4 plants · Avg hydration <span className="font-semibold text-flora-leaf">72%</span> · 2 tasks due today
         </p>
       </div>
@@ -19,9 +24,9 @@ export default function Header() {
         </button>
         <button
           onClick={() => setDark(!dark)}
-          className="p-2 rounded-lg border hover:bg-gray-100 transition"
+          className="p-2 rounded-lg border dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
         >
-          {dark ? <Moon className="w-5 h-5 text-gray-700" /> : <Sun className="w-5 h-5 text-yellow-500" />}
+          {dark ? <Moon className="w-5 h-5 text-gray-200" /> : <Sun className="w-5 h-5 text-yellow-500" />}
         </button>
       </div>
     </header>

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -5,6 +5,7 @@ type PlantCardProps = {
   species: string
   status: string
   hydration: number
+  note?: string
 }
 
 export default function PlantCard({
@@ -12,17 +13,19 @@ export default function PlantCard({
   species,
   status,
   hydration,
+  note,
 }: PlantCardProps) {
   // simple % formatting guard
   const pct = Math.max(0, Math.min(100, Math.round(hydration)))
 
   return (
-    <div className="rounded-lg border p-4 shadow-sm hover:shadow-md transition">
-      <h3 className="font-semibold">
-        {nickname} <span className="italic text-gray-500">— {species}</span>
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
+      <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+        {nickname} <span className="italic text-gray-500 dark:text-gray-400">— {species}</span>
       </h3>
-      <p className="text-sm text-gray-700">{status}</p>
-      <p className="text-xs text-gray-500 mt-1">Hydration: {pct}%</p>
+      <p className="text-sm text-gray-700 dark:text-gray-300">{status}</p>
+      {note && <p className="text-xs text-gray-600 dark:text-gray-400">{note}</p>}
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hydration: {pct}%</p>
     </div>
   )
 }

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -9,10 +9,10 @@ type RoomCardProps = {
 export default function RoomCard({ name, avgHydration, tasksDue }: RoomCardProps) {
   const pct = Math.max(0, Math.min(100, Math.round(avgHydration)))
   return (
-    <div className="rounded-lg border p-4 shadow-sm hover:shadow-md transition">
-      <h3 className="font-semibold">{name}</h3>
-      <p className="text-sm text-gray-700">Avg Hydration: {pct}%</p>
-      <p className="text-sm text-gray-500">{tasksDue} tasks due</p>
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
+      <h3 className="font-semibold text-gray-900 dark:text-gray-100">{name}</h3>
+      <p className="text-sm text-gray-700 dark:text-gray-300">Avg Hydration: {pct}%</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400">{tasksDue} tasks due</p>
     </div>
   )
 }

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -3,19 +3,19 @@ import Link from "next/link"
 
 export default function SidebarNav() {
   return (
-    <aside className="w-64 bg-gray-50 border-r p-6 hidden md:block">
+    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6 hidden md:block">
       <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
-      <nav className="flex flex-col gap-3 text-sm">
-        <Link href="/" className="block px-2 py-1 rounded hover:bg-gray-100">
+      <nav className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200">
+        <Link href="/" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
           Today
         </Link>
-        <Link href="/rooms" className="block px-2 py-1 rounded hover:bg-gray-100">
+        <Link href="/rooms" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
           Rooms
         </Link>
-        <Link href="/science" className="block px-2 py-1 rounded hover:bg-gray-100">
+        <Link href="/science" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
           Science Panel
         </Link>
-        <Link href="/notebook" className="block px-2 py-1 rounded hover:bg-gray-100">
+        <Link href="/notebook" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
           Lab Notebook
         </Link>
       </nav>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,26 +5,26 @@ Flora-Science is a plant care companion designed for **clarity**, **low-friction
 ---
 
 ## ✅ Phase 0 – Foundations
-- [ ] Next.js app structure (`/app`)
-- [ ] Tailwind 
-- [ ] Sidebar navigation + Header
-- [ ] Mock data for Today + Rooms views
+- [x] Next.js app structure (`/app`)
+- [x] Tailwind 
+- [x] Sidebar navigation + Header
+- [x] Mock data for Today + Rooms views
 
 ---
 
 ## 🌱 Phase 1 – Core Views
-- [ ] **Today View**
+- [x] **Today View**
   - Show all plants due today
   - Hydration, fertilizing, and notes at a glance
-- [ ] **Rooms View**
+- [x] **Rooms View**
   - Group plants by room
   - Show average hydration + tasks due
-- [ ] **Plant Detail View**
+- [x] **Plant Detail View**
   - Hero image + nickname/species
   - Quick Stats (hydration, last watered, next due)
   - Timeline of events (water, fertilize, notes, photos)
   - Gallery of plant photos
-- [ ] **Room Detail View**
+- [x] **Room Detail View**
   - Show all plants in room
   - Room-level stats
 
@@ -50,7 +50,7 @@ Flora-Science is a plant care companion designed for **clarity**, **low-friction
 
 ## 🌳 Phase 4 – Polish
 - [ ] Refined UI polish (animations, micro-interactions)
-- [ ] Dark mode
+- [x] Dark mode
 - [ ] Mobile-first layout
 - [ ] Onboarding flow for new users
 


### PR DESCRIPTION
## Summary
- flesh out plant detail page with hero image, stats, timeline, and gallery
- expand room detail view to list plants and room stats
- introduce dark mode toggle and apply styles across components
- show quick notes in Today view and mark completed items in roadmap

## Testing
- `/usr/bin/npm run lint` *(fails: No such file or directory)*
- `/usr/bin/npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c64c0160832487469144dbc0d988