### PR TITLE
Add sidebar navigation to Today and Rooms pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
+import SidebarNav from "@/components/SidebarNav"
 
 type Plant = {
   id: string
@@ -21,27 +22,30 @@ const plants: Plant[] = [
 
 export default function TodayPage() {
   return (
-    <main className="p-6">
-      <header className="mb-4">
-        <h2 className="text-xl font-bold">Today</h2>
-        <p className="text-sm text-gray-500">4 plants · Avg hydration 72% · 2 tasks due today</p>
-      </header>
+    <div className="flex">
+      <SidebarNav />
+      <main className="flex-1 p-6">
+        <header className="mb-4">
+          <h2 className="text-xl font-bold">Today</h2>
+          <p className="text-sm text-gray-500">4 plants · Avg hydration 72% · 2 tasks due today</p>
+        </header>
 
-      <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {plants.map((p) => (
-          <Link key={p.id} href={`/plants/${p.id}`} className="block">
-            <PlantCard
-              nickname={p.nickname}
-              species={p.species}
-              status={p.status}
-              hydration={p.hydration}
-              note={p.note}
-            />
-          </Link>
-        ))}
-      </section>
+        <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {plants.map((p) => (
+            <Link key={p.id} href={`/plants/${p.id}`} className="block">
+              <PlantCard
+                nickname={p.nickname}
+                species={p.species}
+                status={p.status}
+                hydration={p.hydration}
+                note={p.note}
+              />
+            </Link>
+          ))}
+        </section>
 
-      <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
-    </main>
+        <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
+      </main>
+    </div>
   )
 }

--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import RoomCard from "@/components/RoomCard"
+import SidebarNav from "@/components/SidebarNav"
 
 type Room = {
   id: string
@@ -18,18 +19,21 @@ const rooms: Room[] = [
 
 export default function RoomsPage() {
   return (
-    <main className="p-6">
-      <h2 className="text-xl font-bold mb-4">My Rooms</h2>
+    <div className="flex">
+      <SidebarNav />
+      <main className="flex-1 p-6">
+        <h2 className="text-xl font-bold mb-4">My Rooms</h2>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {rooms.map((r) => (
-          <Link key={r.id} href={`/rooms/${r.id}`} className="block">
-            <RoomCard name={r.name} avgHydration={r.avgHydration} tasksDue={r.tasksDue} />
-          </Link>
-        ))}
-      </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {rooms.map((r) => (
+            <Link key={r.id} href={`/rooms/${r.id}`} className="block">
+              <RoomCard name={r.name} avgHydration={r.avgHydration} tasksDue={r.tasksDue} />
+            </Link>
+          ))}
+        </div>
 
-      <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
-    </main>
+        <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
+      </main>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- show navigation on the Today page by including SidebarNav
- render SidebarNav on the Rooms list page for consistent navigation

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint? https://nextjs.org/docs/basic-features/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c819e8488324b8cd83143e874dbf