### PR TITLE
feat: add mobile navigation bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import "./globals.css"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
+import SidebarNav from "@/components/SidebarNav"
+import MobileNav from "@/components/MobileNav"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -19,7 +21,17 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.ico" />
       </head>
-      <body className={`${inter.className} bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`}>{children}</body>
+      <body className={`${inter.className} bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`}>
+        <div className="flex min-h-screen">
+          <div className="hidden md:block">
+            <SidebarNav />
+          </div>
+          <div className="flex-1 pb-16 md:pb-0">{children}</div>
+        </div>
+        <div className="md:hidden">
+          <MobileNav />
+        </div>
+      </body>
     </html>
   )
 }

--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -10,8 +10,8 @@ export default function MobileHome() {
       </header>
 
       <div className="mt-4 space-y-4">
-        <PlantCard nickname="Delilah" species="Monstera deliciosa" status="💧 Overdue" />
-        <PlantCard nickname="Sunny" species="Sansevieria trifasciata" status="✓ Fine" />
+        <PlantCard nickname="Delilah" species="Monstera deliciosa" status="💧 Overdue" hydration={72} />
+        <PlantCard nickname="Sunny" species="Sansevieria trifasciata" status="✓ Fine" hydration={90} />
       </div>
 
       <Footer />

--- a/app/notebook/page.tsx
+++ b/app/notebook/page.tsx
@@ -1,33 +1,29 @@
-import SidebarNav from "@/components/SidebarNav"
 import NotebookEntry from "@/components/NotebookEntry"
 
 export default function NotebookPage() {
   return (
-    <div className="flex">
-      <SidebarNav />
-      <main className="flex-1 p-6">
-        <header className="backdrop-blur bg-white/70 sticky top-0 z-10 p-4 flex items-center justify-between">
-          <h2 className="font-semibold">Lab Notebook</h2>
-          <div className="flex gap-2 text-sm">
-            <button className="px-2 py-1 border rounded">All</button>
-            <button className="px-2 py-1 border rounded">Growth</button>
-            <button className="px-2 py-1 border rounded">Bloom</button>
-          </div>
-        </header>
-
-        <div className="mt-6 space-y-4">
-          <NotebookEntry 
-            icon="🌱" 
-            note="Observation: New leaf unfurled on Delilah (*Monstera deliciosa*)" 
-            date="Aug 28, 2025" 
-          />
-          <NotebookEntry 
-            icon="🐛" 
-            note="Pest check on Sunny (*Sansevieria trifasciata*) — none found" 
-            date="Aug 27, 2025" 
-          />
+    <main className="flex-1 p-6">
+      <header className="backdrop-blur bg-white/70 sticky top-0 z-10 p-4 flex items-center justify-between">
+        <h2 className="font-semibold">Lab Notebook</h2>
+        <div className="flex gap-2 text-sm">
+          <button className="px-2 py-1 border rounded">All</button>
+          <button className="px-2 py-1 border rounded">Growth</button>
+          <button className="px-2 py-1 border rounded">Bloom</button>
         </div>
-      </main>
-    </div>
+      </header>
+
+      <div className="mt-6 space-y-4">
+        <NotebookEntry
+          icon="🌱"
+          note="Observation: New leaf unfurled on Delilah (*Monstera deliciosa*)"
+          date="Aug 28, 2025"
+        />
+        <NotebookEntry
+          icon="🐛"
+          note="Pest check on Sunny (*Sansevieria trifasciata*) — none found"
+          date="Aug 27, 2025"
+        />
+      </div>
+    </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
-import SidebarNav from "@/components/SidebarNav"
 
 type Plant = {
   id: string
@@ -22,30 +21,27 @@ const plants: Plant[] = [
 
 export default function TodayPage() {
   return (
-    <div className="flex">
-      <SidebarNav />
-      <main className="flex-1 p-6">
-        <header className="mb-4">
-          <h2 className="text-xl font-bold">Today</h2>
-          <p className="text-sm text-gray-500">4 plants · Avg hydration 72% · 2 tasks due today</p>
-        </header>
+    <main className="flex-1 p-6">
+      <header className="mb-4">
+        <h2 className="text-xl font-bold">Today</h2>
+        <p className="text-sm text-gray-500">4 plants · Avg hydration 72% · 2 tasks due today</p>
+      </header>
 
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {plants.map((p) => (
-            <Link key={p.id} href={`/plants/${p.id}`} className="block">
-              <PlantCard
-                nickname={p.nickname}
-                species={p.species}
-                status={p.status}
-                hydration={p.hydration}
-                note={p.note}
-              />
-            </Link>
-          ))}
-        </section>
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {plants.map((p) => (
+          <Link key={p.id} href={`/plants/${p.id}`} className="block">
+            <PlantCard
+              nickname={p.nickname}
+              species={p.species}
+              status={p.status}
+              hydration={p.hydration}
+              note={p.note}
+            />
+          </Link>
+        ))}
+      </section>
 
-        <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
-      </main>
-    </div>
+      <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
+    </main>
   )
 }

--- a/app/plants/[id]/page.tsx
+++ b/app/plants/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link"
-import SidebarNav from "@/components/SidebarNav"
 import Header from "@/components/Header"
 
 const samplePlants = {
@@ -58,99 +57,94 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
   const plant = samplePlants[params.id as keyof typeof samplePlants]
 
   return (
-    <div className="flex min-h-screen">
-      <aside className="w-56 border-r bg-gray-50 dark:bg-gray-900 dark:border-gray-700">
-        <SidebarNav />
-      </aside>
-      <main className="flex-1 bg-white dark:bg-gray-900">
-        <Header />
+    <main className="flex-1 bg-white dark:bg-gray-900">
+      <Header />
 
-        <div className="p-6 space-y-6">
-          <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
-            ← Back to Today
-          </Link>
+      <div className="p-6 space-y-6">
+        <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
+          ← Back to Today
+        </Link>
 
-          {!plant ? (
-            <div className="rounded-lg border p-6 dark:border-gray-700">
-              <h2 className="text-xl font-bold">Plant not found</h2>
-              <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
-            </div>
-          ) : (
-            <>
-              <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
-                <img
-                  src={plant.photos[0]}
-                  alt={plant.nickname}
-                  className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
-                />
-                <div className="space-y-2 md:w-1/2 text-center md:text-left">
-                  <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
-                  <p className="italic text-gray-500">{plant.species}</p>
-                  <div className="flex flex-wrap justify-center md:justify-start gap-2 text-sm">
-                    <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">{plant.status}</span>
-                    <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">Hydration: {plant.hydration}%</span>
-                  </div>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    Last watered: <strong>{plant.lastWatered}</strong> · Next due: <strong>{plant.nextDue}</strong>
-                  </p>
+        {!plant ? (
+          <div className="rounded-lg border p-6 dark:border-gray-700">
+            <h2 className="text-xl font-bold">Plant not found</h2>
+            <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
+          </div>
+        ) : (
+          <>
+            <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+              <img
+                src={plant.photos[0]}
+                alt={plant.nickname}
+                className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
+              />
+              <div className="space-y-2 md:w-1/2 text-center md:text-left">
+                <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
+                <p className="italic text-gray-500">{plant.species}</p>
+                <div className="flex flex-wrap justify-center md:justify-start gap-2 text-sm">
+                  <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">{plant.status}</span>
+                  <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">Hydration: {plant.hydration}%</span>
                 </div>
-              </section>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Last watered: <strong>{plant.lastWatered}</strong> · Next due: <strong>{plant.nextDue}</strong>
+                </p>
+              </div>
+            </section>
 
-              <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                {[
-                  { label: "Status", value: plant.status },
-                  { label: "Hydration", value: `${plant.hydration}%` },
-                  { label: "Last Watered", value: plant.lastWatered },
-                  { label: "Next Due", value: plant.nextDue }
-                ].map(({ label, value }) => (
-                  <div
-                    key={label}
-                    className="rounded-xl border p-4 bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
+            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              {[
+                { label: "Status", value: plant.status },
+                { label: "Hydration", value: `${plant.hydration}%` },
+                { label: "Last Watered", value: plant.lastWatered },
+                { label: "Next Due", value: plant.nextDue }
+              ].map(({ label, value }) => (
+                <div
+                  key={label}
+                  className="rounded-xl border p-4 bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
+                >
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+                  <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
+                </div>
+              ))}
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Timeline</h2>
+              <ul className="space-y-2">
+                {plant.events.map((e) => (
+                  <li
+                    key={e.id}
+                    className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
                   >
-                    <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
-                    <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
-                  </div>
+                    <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
+                    <span className="text-sm">
+                      {"note" in e
+                        ? "📝 " + e.note
+                        : e.type === "water"
+                        ? "💧 Watered"
+                        : "🌿 Fertilized"}
+                    </span>
+                  </li>
                 ))}
-              </section>
+              </ul>
+            </section>
 
-              <section>
-                <h2 className="text-lg font-semibold mb-3">Timeline</h2>
-                <ul className="space-y-2">
-                  {plant.events.map((e) => (
-                    <li
-                      key={e.id}
-                      className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
-                    >
-                      <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
-                      <span className="text-sm">
-                        {e.type === "note"
-                          ? "📝 " + e.note
-                          : e.type === "water"
-                          ? "💧 Watered"
-                          : "🌿 Fertilized"}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-
-              <section>
-                <h2 className="text-lg font-semibold mb-3">Gallery</h2>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                  {plant.photos.map((src, i) => (
-                    <img
-                      key={i}
-                      src={src}
-                      alt={`${plant.nickname} photo ${i + 1}`}
-                      className="rounded-lg border object-cover aspect-square transition-transform duration-300 hover:scale-105 dark:border-gray-700"
-                    />
-                  ))}
-                </div>
-              </section>
-            </>
-          )}
-        </div>
-      </main>
-    </div>
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Gallery</h2>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                {plant.photos.map((src, i) => (
+                  <img
+                    key={i}
+                    src={src}
+                    alt={`${plant.nickname} photo ${i + 1}`}
+                    className="rounded-lg border object-cover aspect-square transition-transform duration-300 hover:scale-105 dark:border-gray-700"
+                  />
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </main>
   )
 }

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link"
-import SidebarNav from "@/components/SidebarNav"
 import Header from "@/components/Header"
 import PlantCard from "@/components/PlantCard"
 
@@ -35,45 +34,40 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
   const room = sampleRooms[params.id as keyof typeof sampleRooms]
 
   return (
-    <div className="flex min-h-screen">
-      <aside className="w-56 border-r bg-gray-50 dark:bg-gray-900 dark:border-gray-700">
-        <SidebarNav />
-      </aside>
-      <main className="flex-1 bg-white dark:bg-gray-900">
-        <Header />
+    <main className="flex-1 bg-white dark:bg-gray-900">
+      <Header />
 
-        <div className="p-6 space-y-6">
-          <Link href="/rooms" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
-            ← Back to Rooms
-          </Link>
+      <div className="p-6 space-y-6">
+        <Link href="/rooms" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
+          ← Back to Rooms
+        </Link>
 
-          {!room ? (
-            <div className="rounded-lg border p-6 dark:border-gray-700">
-              <h2 className="text-xl font-bold">Room not found</h2>
-              <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
-            </div>
-          ) : (
-            <>
-              <header>
-                <h1 className="text-2xl font-bold">{room.name}</h1>
-                <p className="text-gray-500">Avg Hydration: {room.hydration}%</p>
-                <p className="text-gray-500">{room.tasks} tasks due</p>
-              </header>
+        {!room ? (
+          <div className="rounded-lg border p-6 dark:border-gray-700">
+            <h2 className="text-xl font-bold">Room not found</h2>
+            <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
+          </div>
+        ) : (
+          <>
+            <header>
+              <h1 className="text-2xl font-bold">{room.name}</h1>
+              <p className="text-gray-500">Avg Hydration: {room.hydration}%</p>
+              <p className="text-gray-500">{room.tasks} tasks due</p>
+            </header>
 
-              <section>
-                <h2 className="font-semibold mb-2">Plants</h2>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {room.plants.map((p) => (
-                    <Link key={p.id} href={`/plants/${p.id}`} className="block">
-                      <PlantCard nickname={p.nickname} species={p.species} status={p.status} hydration={p.hydration} />
-                    </Link>
-                  ))}
-                </div>
-              </section>
-            </>
-          )}
-        </div>
-      </main>
-    </div>
+            <section>
+              <h2 className="font-semibold mb-2">Plants</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {room.plants.map((p) => (
+                  <Link key={p.id} href={`/plants/${p.id}`} className="block">
+                    <PlantCard nickname={p.nickname} species={p.species} status={p.status} hydration={p.hydration} />
+                  </Link>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </main>
   )
 }

--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link"
 import RoomCard from "@/components/RoomCard"
-import SidebarNav from "@/components/SidebarNav"
 
 type Room = {
   id: string
@@ -19,21 +18,18 @@ const rooms: Room[] = [
 
 export default function RoomsPage() {
   return (
-    <div className="flex">
-      <SidebarNav />
-      <main className="flex-1 p-6">
-        <h2 className="text-xl font-bold mb-4">My Rooms</h2>
+    <main className="flex-1 p-6">
+      <h2 className="text-xl font-bold mb-4">My Rooms</h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {rooms.map((r) => (
-            <Link key={r.id} href={`/rooms/${r.id}`} className="block">
-              <RoomCard name={r.name} avgHydration={r.avgHydration} tasksDue={r.tasksDue} />
-            </Link>
-          ))}
-        </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {rooms.map((r) => (
+          <Link key={r.id} href={`/rooms/${r.id}`} className="block">
+            <RoomCard name={r.name} avgHydration={r.avgHydration} tasksDue={r.tasksDue} />
+          </Link>
+        ))}
+      </div>
 
-        <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
-      </main>
-    </div>
+      <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
+    </main>
   )
 }

--- a/app/science/page.tsx
+++ b/app/science/page.tsx
@@ -1,29 +1,25 @@
-import SidebarNav from "@/components/SidebarNav"
 import { TempHumidityChart, VPDGauge } from "@/components/Charts"
 import Footer from "@/components/Footer"
 
 export default function SciencePanel() {
   return (
-    <div className="flex">
-      <SidebarNav />
-      <main className="flex-1 p-6">
-        <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
-          <h2 className="font-semibold text-xl">Science Panel</h2>
-          <button className="px-3 py-1 border rounded hover:bg-gray-100">°F / °C</button>
-        </header>
+    <main className="flex-1 p-6">
+      <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
+        <h2 className="font-semibold text-xl">Science Panel</h2>
+        <button className="px-3 py-1 border rounded hover:bg-gray-100">°F / °C</button>
+      </header>
 
-        <section className="mt-6">
-          <h3 className="font-medium text-gray-800">Environment Data</h3>
-          <TempHumidityChart />
-        </section>
+      <section className="mt-6">
+        <h3 className="font-medium text-gray-800">Environment Data</h3>
+        <TempHumidityChart />
+      </section>
 
-        <section className="mt-6">
-          <h3 className="font-medium text-gray-800">VPD Gauge</h3>
-          <VPDGauge />
-        </section>
+      <section className="mt-6">
+        <h3 className="font-medium text-gray-800">VPD Gauge</h3>
+        <VPDGauge />
+      </section>
 
-        <Footer />
-      </main>
-    </div>
+      <Footer />
+    </main>
   )
 }

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -48,12 +48,7 @@ export function VPDGauge() {
         startAngle={180}
         endAngle={0}
       >
-        <RadialBar
-          minAngle={15}
-          background
-          clockWise
-          dataKey="value"
-        />
+        <RadialBar background dataKey="value" />
         <text
           x="50%"
           y="50%"

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { CalendarDays, LayoutGrid, FlaskConical, Notebook } from "lucide-react"
+
+const navItems = [
+  { href: "/", label: "Today", Icon: CalendarDays },
+  { href: "/rooms", label: "Rooms", Icon: LayoutGrid },
+  { href: "/science", label: "Science", Icon: FlaskConical },
+  { href: "/notebook", label: "Notebook", Icon: Notebook },
+]
+
+export default function MobileNav() {
+  const pathname = usePathname()
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 border-t bg-white dark:bg-gray-900 flex justify-around py-2">
+      {navItems.map(({ href, label, Icon }) => {
+        const active = href === "/" ? pathname === href : pathname.startsWith(href)
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`flex flex-col items-center text-xs ${active ? "text-flora-leaf" : "text-gray-500"}`}
+          >
+            <Icon className="w-6 h-6" />
+            <span className="sr-only">{label}</span>
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -1,23 +1,33 @@
 "use client"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 
 export default function SidebarNav() {
+  const pathname = usePathname()
+
+  const links = [
+    { href: "/", label: "Today" },
+    { href: "/rooms", label: "Rooms" },
+    { href: "/science", label: "Science Panel" },
+    { href: "/notebook", label: "Lab Notebook" },
+  ]
+
   return (
-    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6 hidden md:block">
+    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
       <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
       <nav className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200">
-        <Link href="/" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-          Today
-        </Link>
-        <Link href="/rooms" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-          Rooms
-        </Link>
-        <Link href="/science" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-          Science Panel
-        </Link>
-        <Link href="/notebook" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-          Lab Notebook
-        </Link>
+        {links.map(({ href, label }) => {
+          const active = href === "/" ? pathname === href : pathname.startsWith(href)
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${active ? "bg-gray-200 dark:bg-gray-800 font-medium" : ""}`}
+            >
+              {label}
+            </Link>
+          )
+        })}
       </nav>
     </aside>
   )


### PR DESCRIPTION
## Summary
- add MobileNav with icon-based links
- render SidebarNav on desktop and MobileNav on mobile
- highlight active routes with usePathname

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b3d14d0ea48324bf5e30f57c736c59