### PR TITLE
Use SidebarNav component for detail pages

### DIFF
--- a/app/plants/[id]/page.tsx
+++ b/app/plants/[id]/page.tsx
@@ -59,9 +59,7 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-56 border-r bg-gray-50 dark:bg-gray-900 dark:border-gray-700">
-        <SidebarNav />
-      </aside>
+      <SidebarNav />
       <main className="flex-1 bg-white dark:bg-gray-900">
         <Header />
 

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -36,9 +36,7 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-56 border-r bg-gray-50 dark:bg-gray-900 dark:border-gray-700">
-        <SidebarNav />
-      </aside>
+      <SidebarNav />
       <main className="flex-1 bg-white dark:bg-gray-900">
         <Header />
 


### PR DESCRIPTION
## Summary
- remove extra aside wrappers from plant and room detail pages in favor of the SidebarNav component
- ensure main content spans full width on mobile when sidebar is hidden

## Testing
- `pnpm lint` *(fails: prompted for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1586fd483249d668be68ea5abf0