### PR TITLE
Implement mobile tab bar and improve navigation responsiveness

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,13 +1,19 @@
 import SidebarNav from "@/components/SidebarNav"
 import Header from "@/components/Header"
+import MobileNav from "@/components/MobileNav"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col md:flex-row min-h-screen">
-      <SidebarNav />
-      <div className="flex-1 flex flex-col">
+      <div className="hidden md:block">
+        <SidebarNav />
+      </div>
+      <div className="flex-1 flex flex-col pb-16 md:pb-0">
         <Header />
         {children}
+      </div>
+      <div className="md:hidden">
+        <MobileNav />
       </div>
     </div>
   )

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,0 +1,33 @@
+"use client"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Calendar, Home, FlaskConical, Notebook } from "lucide-react"
+
+const navItems = [
+  { href: "/", label: "Today", icon: Calendar },
+  { href: "/rooms", label: "Rooms", icon: Home },
+  { href: "/science", label: "Science", icon: FlaskConical },
+  { href: "/notebook", label: "Notebook", icon: Notebook },
+]
+
+export default function MobileNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex justify-around py-2 text-xs">
+      {navItems.map(({ href, label, icon: Icon }) => {
+        const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`flex flex-col items-center gap-1 px-3 py-1 ${active ? "text-flora-leaf" : "text-gray-700 dark:text-gray-200"}`}
+          >
+            <Icon className="h-5 w-5" />
+            <span>{label}</span>
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -1,33 +1,34 @@
 "use client"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+const navItems = [
+  { href: "/", label: "Today" },
+  { href: "/rooms", label: "Rooms" },
+  { href: "/science", label: "Science Panel" },
+  { href: "/notebook", label: "Lab Notebook" },
+]
 
 export default function SidebarNav() {
-  return (
-    <>
-      <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6 hidden md:block">
-        <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
-        <nav className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200">
-          <Link href="/" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-            Today
-          </Link>
-          <Link href="/rooms" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-            Rooms
-          </Link>
-          <Link href="/science" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-            Science Panel
-          </Link>
-          <Link href="/notebook" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-            Lab Notebook
-          </Link>
-        </nav>
-      </aside>
+  const pathname = usePathname()
 
-      <nav className="fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex justify-around py-2 md:hidden text-sm">
-        <Link href="/" className="px-3 py-1">Today</Link>
-        <Link href="/rooms" className="px-3 py-1">Rooms</Link>
-        <Link href="/science" className="px-3 py-1">Science</Link>
-        <Link href="/notebook" className="px-3 py-1">Notebook</Link>
+  return (
+    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
+      <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
+      <nav className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200">
+        {navItems.map(({ href, label }) => {
+          const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${active ? "bg-gray-100 dark:bg-gray-800 text-flora-leaf" : ""}`}
+            >
+              {label}
+            </Link>
+          )
+        })}
       </nav>
-    </>
+    </aside>
   )
 }


### PR DESCRIPTION
## Summary
- separate sidebar and mobile navigation components
- add icon-based mobile tab bar
- update dashboard layout to show sidebar on desktop and mobile nav on small screens

## Testing
- `pnpm lint` *(fails: prompts for configuration)*
- `pnpm build` *(fails: RadialBar type error in Charts.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d5e10b9c83249f4893331a57b0f6