### PR TITLE
feat: persist theme preference with reusable hook

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,14 +1,9 @@
 "use client"
 import { PlusCircle, Sun, Moon } from "lucide-react"
-import { useState, useEffect } from "react"
+import { useTheme } from "@/hooks/useTheme"
 
 export default function Header() {
-  const [dark, setDark] = useState(false)
-
-  useEffect(() => {
-    const root = document.documentElement
-    root.classList.toggle("dark", dark)
-  }, [dark])
+  const { theme, toggleTheme } = useTheme()
 
   return (
     <header className="backdrop-blur bg-white/80 dark:bg-gray-900/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
@@ -23,10 +18,10 @@ export default function Header() {
           <PlusCircle className="w-4 h-4" /> Add
         </button>
         <button
-          onClick={() => setDark(!dark)}
+          onClick={toggleTheme}
           className="p-2 rounded-lg border dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
         >
-          {dark ? <Moon className="w-5 h-5 text-gray-200" /> : <Sun className="w-5 h-5 text-yellow-500" />}
+          {theme === "dark" ? <Moon className="w-5 h-5 text-gray-200" /> : <Sun className="w-5 h-5 text-yellow-500" />}
         </button>
       </div>
     </header>

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,31 @@
+"use client"
+import { useState, useEffect, useCallback } from "react"
+
+type Theme = "light" | "dark"
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>("light")
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme")
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored)
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+      setTheme(prefersDark ? "dark" : "light")
+    }
+  }, [])
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    root.classList.toggle("dark", theme === "dark")
+    window.localStorage.setItem("theme", theme)
+  }, [theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"))
+  }, [])
+
+  return { theme, toggleTheme }
+}
+


### PR DESCRIPTION
## Summary
- add `useTheme` hook to manage dark/light mode and persist choice in localStorage
- use `useTheme` in Header component to toggle theme and sync DOM class

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d98309bc832496bfc3271f2fc6b9