### PR TITLE
feat: centralize last sync timestamp logic

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import RoomCard from "@/components/RoomCard"
+import { getLastSync } from "@/lib/utils"
 
 type Room = {
   id: string
@@ -29,7 +30,7 @@ export default function RoomsPage() {
         ))}
       </div>
 
-      <footer className="text-xs text-gray-400 mt-6">Last sync: 10:32 AM CDT</footer>
+      <footer className="text-xs text-gray-400 mt-6">Last sync: {getLastSync()}</footer>
     </main>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,9 +1,16 @@
 "use client"
 
-export default function Footer() {
+import { getLastSync } from "@/lib/utils"
+
+type FooterProps = {
+  lastSync?: string
+}
+
+export default function Footer({ lastSync }: FooterProps) {
+  const syncTime = lastSync ?? getLastSync()
   return (
     <footer className="mt-6 text-xs text-gray-500">
-      Last sync: 10:32 AM CDT
+      Last sync: {syncTime}
     </footer>
   )
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,9 @@
+export function getLastSync(): string {
+  return new Date().toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  })
+}
+
+// TODO: Wire to real sync events once data persistence is available.


### PR DESCRIPTION
## Summary
- add helper to format last sync timestamps
- use timestamp helper in `Footer` and rooms page

## Testing
- `pnpm lint` (fails: prompts for ESLint configuration)
- `pnpm build` (fails: Type error in `Charts.tsx`)


------
https://chatgpt.com/codex/tasks/task_e_68b3d98f20c4832481c62bffa685524e