### PR TITLE
Integrate Supabase client and dynamic data fetching

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,26 +1,35 @@
-"use client"
-
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
 import Footer from "@/components/Footer"
+import { supabase, Plant } from "@/lib/supabase"
 
-type Plant = {
-  id: string
-  nickname: string
-  species: string
-  status: string
-  hydration: number
-  note?: string
-}
+export default async function TodayPage() {
+  const { data: plants, error } = await supabase.from("plants").select("*")
 
-const plants: Plant[] = [
-  { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72, note: "Needs water" },
-  { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90, note: "Loves bright light" },
-  { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70, note: "Trailing nicely" },
-  { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75, note: "New growth" },
-]
+  if (error) {
+    return (
+      <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6">
+        <p className="text-red-500">Failed to load plants: {error.message}</p>
+      </main>
+    )
+  }
 
-export default function TodayPage() {
+  if (!plants) {
+    return (
+      <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6">
+        <p>Loading...</p>
+      </main>
+    )
+  }
+
+  const avg =
+    plants.length > 0
+      ? Math.round(
+          plants.reduce((sum, p) => sum + (p.hydration ?? 0), 0) / plants.length
+        )
+      : 0
+  const tasksDue = plants.filter((p) => p.status?.toLowerCase().includes("due")).length
+
   return (
     <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6">
       <header className="sticky top-0 z-10 backdrop-blur bg-white/70 dark:bg-gray-900/70 p-2 flex items-center justify-between md:hidden">
@@ -30,18 +39,18 @@ export default function TodayPage() {
 
       <header className="mt-4 mb-4 hidden md:block">
         <h2 className="text-xl font-bold">Today</h2>
-        <p className="text-sm text-gray-500">4 plants · Avg hydration 72% · 2 tasks due today</p>
+        <p className="text-sm text-gray-500">{plants.length} plants · Avg hydration {avg}% · {tasksDue} tasks due today</p>
       </header>
 
       <section className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-        {plants.map((p) => (
+        {plants.map((p: Plant) => (
           <Link key={p.id} href={`/plants/${p.id}`} className="block">
             <PlantCard
               nickname={p.nickname}
               species={p.species}
               status={p.status}
               hydration={p.hydration}
-              note={p.note}
+              note={p.note || undefined}
             />
           </Link>
         ))}

--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -1,146 +1,143 @@
 import Link from "next/link"
+import { supabase, Plant, CareEvent } from "@/lib/supabase"
 
-const samplePlants = {
-  "1": {
-    nickname: "Delilah",
-    species: "Monstera deliciosa",
-    status: "Water overdue",
-    hydration: 72,
-    lastWatered: "Aug 25",
-    nextDue: "Aug 30",
-    events: [
-      { id: 1, type: "water", date: "Aug 25" },
-      { id: 2, type: "note", date: "Aug 20", note: "New leaf unfurling" }
-    ],
-    photos: [
-      "https://placehold.co/800x400?text=Delilah",
-      "https://placehold.co/300x300?text=Delilah"
-    ]
-  },
-  "2": {
-    nickname: "Sunny",
-    species: "Sansevieria trifasciata",
-    status: "Fine",
-    hydration: 90,
-    lastWatered: "Aug 27",
-    nextDue: "Sep 5",
-    events: [{ id: 1, type: "water", date: "Aug 27" }],
-    photos: ["https://placehold.co/800x400?text=Sunny"]
-  },
-  "3": {
-    nickname: "Ivy",
-    species: "Epipremnum aureum",
-    status: "Due today",
-    hydration: 70,
-    lastWatered: "Aug 28",
-    nextDue: "Aug 29",
-    events: [{ id: 1, type: "water", date: "Aug 28" }],
-    photos: ["https://placehold.co/800x400?text=Ivy"]
-  },
-  "4": {
-    nickname: "Figgy",
-    species: "Ficus lyrata",
-    status: "Fertilize suggested",
-    hydration: 75,
-    lastWatered: "Aug 23",
-    nextDue: "Sep 2",
-    events: [
-      { id: 1, type: "fertilize", date: "Aug 15" },
-      { id: 2, type: "water", date: "Aug 23" }
-    ],
-    photos: ["https://placehold.co/800x400?text=Figgy"]
+export default async function PlantDetailPage({ params }: { params: { id: string } }) {
+  const { data: plant, error } = await supabase
+    .from("plants")
+    .select("*")
+    .eq("id", params.id)
+    .single()
+
+  const { data: events, error: eventsError } = await supabase
+    .from("care_events")
+    .select("*")
+    .eq("plant_id", params.id)
+
+  if (error || eventsError) {
+    return (
+      <main className="flex-1 bg-white dark:bg-gray-900">
+        <div className="p-6">
+          <p className="text-red-500">Failed to load plant.</p>
+        </div>
+      </main>
+    )
   }
-}
 
-export default function PlantDetailPage({ params }: { params: { id: string } }) {
-  const plant = samplePlants[params.id as keyof typeof samplePlants]
-
-  return (
-    <main className="flex-1 bg-white dark:bg-gray-900">
-      <div className="p-6 space-y-6">
-        <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
-          ← Back to Today
-        </Link>
-
-        {!plant ? (
+  if (!plant) {
+    return (
+      <main className="flex-1 bg-white dark:bg-gray-900">
+        <div className="p-6 space-y-6">
+          <Link
+            href="/"
+            className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+          >
+            ← Back to Today
+          </Link>
           <div className="rounded-lg border p-6 dark:border-gray-700">
             <h2 className="text-xl font-bold">Plant not found</h2>
             <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
           </div>
-        ) : (
-          <>
-            <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
-              <img
-                src={plant.photos[0]}
-                alt={plant.nickname}
-                className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
-              />
-              <div className="space-y-2 md:w-1/2 text-center md:text-left">
-                <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
-                <p className="italic text-gray-500">{plant.species}</p>
-                <div className="flex flex-wrap justify-center md:justify-start gap-2 text-sm">
-                  <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">{plant.status}</span>
-                  <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">Hydration: {plant.hydration}%</span>
-                </div>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Last watered: <strong>{plant.lastWatered}</strong> · Next due: <strong>{plant.nextDue}</strong>
-                </p>
-              </div>
-            </section>
+        </div>
+      </main>
+    )
+  }
 
-            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-              {[
-                { label: "Status", value: plant.status },
-                { label: "Hydration", value: `${plant.hydration}%` },
-                { label: "Last Watered", value: plant.lastWatered },
-                { label: "Next Due", value: plant.nextDue }
-              ].map(({ label, value }) => (
-                <div
-                  key={label}
-                  className="rounded-xl border p-4 bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
+  return (
+    <main className="flex-1 bg-white dark:bg-gray-900">
+      <div className="p-6 space-y-6">
+        <Link
+          href="/"
+          className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+        >
+          ← Back to Today
+        </Link>
+
+        <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+          {plant.photos && plant.photos.length > 0 && (
+            <img
+              src={plant.photos[0]}
+              alt={plant.nickname}
+              className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
+            />
+          )}
+          <div className="space-y-2 md:w-1/2 text-center md:text-left">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
+            <p className="italic text-gray-500">{plant.species}</p>
+            <div className="flex flex-wrap justify-center md:justify-start gap-2 text-sm">
+              {plant.status && (
+                <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">
+                  {plant.status}
+                </span>
+              )}
+              <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">
+                Hydration: {plant.hydration}%
+              </span>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Last watered: <strong>{plant.last_watered ?? "?"}</strong> · Next due: <strong>{plant.next_due ?? "?"}</strong>
+            </p>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[
+            { label: "Status", value: plant.status },
+            { label: "Hydration", value: `${plant.hydration}%` },
+            { label: "Last Watered", value: plant.last_watered ?? "?" },
+            { label: "Next Due", value: plant.next_due ?? "?" }
+          ].map(({ label, value }) => (
+            <div
+              key={label}
+              className="rounded-xl border p-4 bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
+            >
+              <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+              <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
+            </div>
+          ))}
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold mb-3">Timeline</h2>
+          <ul className="space-y-2">
+            {events && events.length > 0 ? (
+              events.map((e: CareEvent) => (
+                <li
+                  key={e.id}
+                  className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
                 >
-                  <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
-                  <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
-                </div>
-              ))}
-            </section>
+                  <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
+                  <span className="text-sm">
+                    {e.type === "note"
+                      ? `📝 ${e.note ?? ""}`
+                      : e.type === "water"
+                      ? "💧 Watered"
+                      : "🌿 Fertilized"}
+                  </span>
+                </li>
+              ))
+            ) : (
+              <p className="text-sm text-gray-500">No events recorded.</p>
+            )}
+          </ul>
+        </section>
 
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Timeline</h2>
-              <ul className="space-y-2">
-                {plant.events.map((e) => (
-                  <li
-                    key={e.id}
-                    className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
-                  >
-                    <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
-                    <span className="text-sm">
-                      {e.type === "note"
-                        ? "📝 " + (e as any).note
-                        : e.type === "water"
-                        ? "💧 Watered"
-                        : "🌿 Fertilized"}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Gallery</h2>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                {plant.photos.map((src, i) => (
-                  <img
-                    key={i}
-                    src={src}
-                    alt={`${plant.nickname} photo ${i + 1}`}
-                    className="rounded-lg border object-cover aspect-square transition-transform duration-300 hover:scale-105 dark:border-gray-700"
-                  />
-                ))}
-              </div>
-            </section>
-          </>
-        )}
+        <section>
+          <h2 className="text-lg font-semibold mb-3">Gallery</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {plant.photos && plant.photos.length > 0 ? (
+              plant.photos.map((src, i) => (
+                <img
+                  key={i}
+                  src={src}
+                  alt={`${plant.nickname} photo ${i + 1}`}
+                  className="rounded-lg border object-cover aspect-square transition-transform duration-300 hover:scale-105 dark:border-gray-700"
+                />
+              ))
+            ) : (
+              <p className="text-sm text-gray-500">No photos.</p>
+            )}
+          </div>
+        </section>
       </div>
     </main>
   )

--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,69 +1,83 @@
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
+import { supabase, Plant } from "@/lib/supabase"
 
-const sampleRooms = {
-  "living-room": {
-    name: "Living Room",
-    hydration: 72,
-    tasks: 2,
-    plants: [
-      { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72 },
-      { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70 }
-    ]
-  },
-  "bedroom": {
-    name: "Bedroom",
-    hydration: 65,
-    tasks: 1,
-    plants: [
-      { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90 }
-    ]
-  },
-  "office": {
-    name: "Office",
-    hydration: 82,
-    tasks: 0,
-    plants: [
-      { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75 }
-    ]
+export default async function RoomDetailPage({ params }: { params: { id: string } }) {
+  const { data: room, error } = await supabase
+    .from("rooms")
+    .select("*")
+    .eq("id", params.id)
+    .single()
+
+  const { data: plants, error: plantsError } = await supabase
+    .from("plants")
+    .select("*")
+    .eq("room_id", params.id)
+
+  if (error || plantsError) {
+    return (
+      <main className="flex-1 bg-white dark:bg-gray-900">
+        <div className="p-6">
+          <p className="text-red-500">Failed to load room.</p>
+        </div>
+      </main>
+    )
   }
-}
 
-export default function RoomDetailPage({ params }: { params: { id: string } }) {
-  const room = sampleRooms[params.id as keyof typeof sampleRooms]
-
-  return (
-    <main className="flex-1 bg-white dark:bg-gray-900">
-      <div className="p-6 space-y-6">
-        <Link href="/rooms" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
-          ← Back to Rooms
-        </Link>
-
-        {!room ? (
+  if (!room) {
+    return (
+      <main className="flex-1 bg-white dark:bg-gray-900">
+        <div className="p-6 space-y-6">
+          <Link
+            href="/rooms"
+            className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+          >
+            ← Back to Rooms
+          </Link>
           <div className="rounded-lg border p-6 dark:border-gray-700">
             <h2 className="text-xl font-bold">Room not found</h2>
             <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>
           </div>
-        ) : (
-          <>
-            <header>
-              <h1 className="text-2xl font-bold">{room.name}</h1>
-              <p className="text-gray-500">Avg Hydration: {room.hydration}%</p>
-              <p className="text-gray-500">{room.tasks} tasks due</p>
-            </header>
+        </div>
+      </main>
+    )
+  }
 
-            <section>
-              <h2 className="font-semibold mb-2">Plants</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {room.plants.map((p) => (
-                  <Link key={p.id} href={`/plants/${p.id}`} className="block">
-                    <PlantCard nickname={p.nickname} species={p.species} status={p.status} hydration={p.hydration} />
-                  </Link>
-                ))}
-              </div>
-            </section>
-          </>
-        )}
+  return (
+    <main className="flex-1 bg-white dark:bg-gray-900">
+      <div className="p-6 space-y-6">
+        <Link
+          href="/rooms"
+          className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+        >
+          ← Back to Rooms
+        </Link>
+
+        <header>
+          <h1 className="text-2xl font-bold">{room.name}</h1>
+          <p className="text-gray-500">Avg Hydration: {room.avg_hydration ?? 0}%</p>
+          <p className="text-gray-500">{room.tasks_due ?? 0} tasks due</p>
+        </header>
+
+        <section>
+          <h2 className="font-semibold mb-2">Plants</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {plants && plants.length > 0 ? (
+              plants.map((p: Plant) => (
+                <Link key={p.id} href={`/plants/${p.id}`} className="block">
+                  <PlantCard
+                    nickname={p.nickname}
+                    species={p.species}
+                    status={p.status}
+                    hydration={p.hydration}
+                  />
+                </Link>
+              ))
+            ) : (
+              <p className="text-sm text-gray-500">No plants found.</p>
+            )}
+          </div>
+        </section>
       </div>
     </main>
   )

--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -1,30 +1,38 @@
-"use client"
-
 import Link from "next/link"
 import RoomCard from "@/components/RoomCard"
+import { supabase, Room } from "@/lib/supabase"
 
-type Room = {
-  id: string
-  name: string
-  avgHydration: number
-  tasksDue: number
-}
+export default async function RoomsPage() {
+  const { data: rooms, error } = await supabase.from("rooms").select("*")
 
-const rooms: Room[] = [
-  { id: "living-room", name: "Living Room", avgHydration: 72, tasksDue: 2 },
-  { id: "bedroom", name: "Bedroom", avgHydration: 65, tasksDue: 1 },
-  { id: "office", name: "Office", avgHydration: 82, tasksDue: 0 },
-]
+  if (error) {
+    return (
+      <main className="flex-1 p-6">
+        <p className="text-red-500">Failed to load rooms: {error.message}</p>
+      </main>
+    )
+  }
 
-export default function RoomsPage() {
+  if (!rooms) {
+    return (
+      <main className="flex-1 p-6">
+        <p>Loading...</p>
+      </main>
+    )
+  }
+
   return (
     <main className="flex-1 p-6">
       <h2 className="text-xl font-bold mb-4">My Rooms</h2>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {rooms.map((r) => (
+        {rooms.map((r: Room) => (
           <Link key={r.id} href={`/rooms/${r.id}`} className="block">
-            <RoomCard name={r.name} avgHydration={r.avgHydration} tasksDue={r.tasksDue} />
+            <RoomCard
+              name={r.name}
+              avgHydration={r.avg_hydration || 0}
+              tasksDue={r.tasks_due || 0}
+            />
           </Link>
         ))}
       </div>

--- a/app/api/care-events/[id]/route.ts
+++ b/app/api/care-events/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+import { supabase, CareEvent } from "@/lib/supabase"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { data, error } = await supabase
+    .from("care_events")
+    .select("*")
+    .eq("id", params.id)
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const body = (await request.json()) as Partial<CareEvent>
+  const { data, error } = await supabase
+    .from("care_events")
+    .update(body)
+    .eq("id", params.id)
+    .select()
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { error } = await supabase
+    .from("care_events")
+    .delete()
+    .eq("id", params.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/app/api/care-events/route.ts
+++ b/app/api/care-events/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+import { supabase, CareEvent } from "@/lib/supabase"
+
+export async function GET() {
+  const { data, error } = await supabase.from("care_events").select("*")
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as CareEvent
+  const { data, error } = await supabase
+    .from("care_events")
+    .insert(body)
+    .select()
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/app/api/plants/[id]/route.ts
+++ b/app/api/plants/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import { supabase, Plant } from "@/lib/supabase"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { data, error } = await supabase
+    .from("plants")
+    .select("*")
+    .eq("id", params.id)
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const body = (await request.json()) as Partial<Plant>
+  const { data, error } = await supabase
+    .from("plants")
+    .update(body)
+    .eq("id", params.id)
+    .select()
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { error } = await supabase.from("plants").delete().eq("id", params.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+import { supabase, Plant } from "@/lib/supabase"
+
+export async function GET() {
+  const { data, error } = await supabase.from("plants").select("*")
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as Plant
+  const { data, error } = await supabase.from("plants").insert(body).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/app/api/rooms/[id]/route.ts
+++ b/app/api/rooms/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import { supabase, Room } from "@/lib/supabase"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { data, error } = await supabase
+    .from("rooms")
+    .select("*")
+    .eq("id", params.id)
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const body = (await request.json()) as Partial<Room>
+  const { data, error } = await supabase
+    .from("rooms")
+    .update(body)
+    .eq("id", params.id)
+    .select()
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { error } = await supabase.from("rooms").delete().eq("id", params.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+import { supabase, Room } from "@/lib/supabase"
+
+export async function GET() {
+  const { data, error } = await supabase.from("rooms").select("*")
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as Room
+  const { data, error } = await supabase.from("rooms").insert(body).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,103 @@
+import { createClient } from '@supabase/supabase-js'
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      plants: {
+        Row: {
+          id: string
+          nickname: string
+          species: string
+          status: string
+          hydration: number
+          note: string | null
+          room_id: string | null
+          last_watered: string | null
+          next_due: string | null
+          photos: string[] | null
+        }
+        Insert: {
+          id?: string
+          nickname: string
+          species: string
+          status?: string
+          hydration?: number
+          note?: string | null
+          room_id?: string | null
+          last_watered?: string | null
+          next_due?: string | null
+          photos?: string[] | null
+        }
+        Update: {
+          nickname?: string
+          species?: string
+          status?: string
+          hydration?: number
+          note?: string | null
+          room_id?: string | null
+          last_watered?: string | null
+          next_due?: string | null
+          photos?: string[] | null
+        }
+      }
+      rooms: {
+        Row: {
+          id: string
+          name: string
+          avg_hydration: number | null
+          tasks_due: number | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          avg_hydration?: number | null
+          tasks_due?: number | null
+        }
+        Update: {
+          name?: string
+          avg_hydration?: number | null
+          tasks_due?: number | null
+        }
+      }
+      care_events: {
+        Row: {
+          id: string
+          plant_id: string
+          type: string
+          date: string
+          note: string | null
+        }
+        Insert: {
+          id?: string
+          plant_id: string
+          type: string
+          date: string
+          note?: string | null
+        }
+        Update: {
+          plant_id?: string
+          type?: string
+          date?: string
+          note?: string | null
+        }
+      }
+    }
+  }
+}
+
+export type Plant = Database['public']['Tables']['plants']['Row']
+export type Room = Database['public']['Tables']['rooms']['Row']
+export type CareEvent = Database['public']['Tables']['care_events']['Row']
+
+export const supabase = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.56.1",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.344.0",
     "next": "14.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.56.1
+        version: 2.56.1
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -146,6 +149,28 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@supabase/auth-js@2.71.1':
+    resolution: {integrity: sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==}
+
+  '@supabase/functions-js@2.4.5':
+    resolution: {integrity: sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==}
+
+  '@supabase/node-fetch@2.6.15':
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+
+  '@supabase/postgrest-js@1.21.3':
+    resolution: {integrity: sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==}
+
+  '@supabase/realtime-js@2.15.4':
+    resolution: {integrity: sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==}
+
+  '@supabase/storage-js@2.11.0':
+    resolution: {integrity: sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==}
+
+  '@supabase/supabase-js@2.56.1':
+    resolution: {integrity: sha512-cb/kS0d6G/qbcmUFItkqVrQbxQHWXzfRZuoiSDv/QiU6RbGNTn73XjjvmbBCZ4MMHs+5teihjhpEVluqbXISEg==}
+
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
 
@@ -179,8 +204,14 @@ packages:
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -760,6 +791,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -786,6 +820,12 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -798,6 +838,18 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
@@ -877,6 +929,48 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@supabase/auth-js@2.71.1':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/functions-js@2.4.5':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/node-fetch@2.6.15':
+    dependencies:
+      whatwg-url: 5.0.0
+
+  '@supabase/postgrest-js@1.21.3':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/realtime-js@2.15.4':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.11.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/supabase-js@2.56.1':
+    dependencies:
+      '@supabase/auth-js': 2.71.1
+      '@supabase/functions-js': 2.4.5
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.21.3
+      '@supabase/realtime-js': 2.15.4
+      '@supabase/storage-js': 2.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.2':
     dependencies:
       tslib: 2.8.1
@@ -909,9 +1003,15 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.1.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.3.0
 
   ansi-regex@5.0.1: {}
 
@@ -1468,6 +1568,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1: {}
@@ -1501,6 +1603,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -1516,5 +1625,7 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  ws@8.18.3: {}
 
   yaml@2.8.1: {}


### PR DESCRIPTION
## Summary
- add Supabase client with typed tables for plants, rooms, and care events
- replace static mock data with Supabase queries and basic loading/error handling
- expose CRUD API routes for plants, rooms, and care events

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d988e5208324bedbe7dcec43000b