### PR TITLE
Add accessible labels to header buttons

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,14 +14,25 @@ export default function Header() {
         </p>
       </div>
       <div className="flex items-center gap-3">
-        <button className="flex items-center gap-1 px-3 py-2 rounded-lg bg-flora-leaf text-white hover:bg-green-600 transition">
-          <PlusCircle className="w-4 h-4" /> Add
+        <button
+          aria-label="Add plant"
+          className="flex items-center gap-1 px-3 py-2 rounded-lg bg-flora-leaf text-white hover:bg-green-600 transition"
+        >
+          <PlusCircle className="w-4 h-4" aria-hidden="true" />
+          <span aria-hidden="true">Add</span>
+          <span className="sr-only">Add plant</span>
         </button>
         <button
           onClick={toggleTheme}
+          aria-label="Toggle theme"
           className="p-2 rounded-lg border dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
         >
-          {theme === "dark" ? <Moon className="w-5 h-5 text-gray-200" /> : <Sun className="w-5 h-5 text-yellow-500" />}
+          {theme === "dark" ? (
+            <Moon className="w-5 h-5 text-gray-200" aria-hidden="true" />
+          ) : (
+            <Sun className="w-5 h-5 text-yellow-500" aria-hidden="true" />
+          )}
+          <span className="sr-only">Toggle theme</span>
         </button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- provide aria-labels for add and theme toggle buttons
- include screen-reader-only descriptions and hide decorative icons

## Testing
- `pnpm lint` *(fails: requires interactive setup)*
- `pnpm test` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b44ecdc724832486d965aa4d51419e