### PR TITLE
chore: convert eligible components to server

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
 import Footer from "@/components/Footer"

--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import Link from "next/link"
 import RoomCard from "@/components/RoomCard"
 import { getLastSync } from "@/lib/utils"

--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import Link from "next/link"
 import { ReactNode } from "react"
 

--- a/components/EnvRow.tsx
+++ b/components/EnvRow.tsx
@@ -1,4 +1,3 @@
-"use client"
 import { Thermometer, Droplets, Wind } from "lucide-react"
 
 export default function EnvRow() {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { getLastSync } from "@/lib/utils"
 
 type FooterProps = {

--- a/components/NotebookEntry.tsx
+++ b/components/NotebookEntry.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 type Props = {
   icon: string
   note: string

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 type PlantCardProps = {
   nickname: string
   species: string

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 type RoomCardProps = {
   name: string
   avgHydration: number


### PR DESCRIPTION
## Summary
- remove `"use client"` from components that don't use hooks or browser APIs
- adjust dashboard pages to render new server components

## Testing
- `pnpm lint` *(fails: prompts for ESLint setup)*
- `pnpm test` *(fails: Test failed; see logs)*
- `pnpm build` *(fails: Type error in components/Charts.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e3223788324a8a0e7ed40ed91d9