### PR TITLE
Add hydration progress bars and task badges

### DIFF
--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -3,6 +3,7 @@ type PlantCardProps = {
   species: string
   status: string
   hydration: number
+  tasksDue?: number
   note?: string
 }
 
@@ -11,10 +12,13 @@ export default function PlantCard({
   species,
   status,
   hydration,
+  tasksDue = 0,
   note,
 }: PlantCardProps) {
   // simple % formatting guard
   const pct = Math.max(0, Math.min(100, Math.round(hydration)))
+  const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
+  const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
 
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
@@ -23,7 +27,30 @@ export default function PlantCard({
       </h3>
       <p className="text-sm text-gray-700 dark:text-gray-300">{status}</p>
       {note && <p className="text-xs text-gray-600 dark:text-gray-400">{note}</p>}
-      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hydration: {pct}%</p>
+      <div
+        className="w-full bg-gray-200 rounded-full h-2 mt-2"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className={`h-2 rounded-full ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between mt-2">
+        <p className="text-xs text-gray-500 dark:text-gray-400">Hydration: {pct}%</p>
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500 dark:text-gray-400">Tasks</span>
+          <span
+            className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badgeColor}`}
+            aria-label={`${tasksDue} tasks due`}
+          >
+            {tasksDue}
+          </span>
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -6,11 +6,35 @@ type RoomCardProps = {
 
 export default function RoomCard({ name, avgHydration, tasksDue }: RoomCardProps) {
   const pct = Math.max(0, Math.min(100, Math.round(avgHydration)))
+  const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
+  const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
       <h3 className="font-semibold text-gray-900 dark:text-gray-100">{name}</h3>
-      <p className="text-sm text-gray-700 dark:text-gray-300">Avg Hydration: {pct}%</p>
-      <p className="text-sm text-gray-500 dark:text-gray-400">{tasksDue} tasks due</p>
+      <div
+        className="w-full bg-gray-200 rounded-full h-2 mt-2"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className={`h-2 rounded-full ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between mt-2">
+        <p className="text-sm text-gray-700 dark:text-gray-300">Avg Hydration: {pct}%</p>
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500 dark:text-gray-400">Tasks</span>
+          <span
+            className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badgeColor}`}
+            aria-label={`${tasksDue} tasks due`}
+          >
+            {tasksDue}
+          </span>
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/__tests__/PlantCard.test.tsx
+++ b/components/__tests__/PlantCard.test.tsx
@@ -2,21 +2,28 @@ import { render, screen } from '@testing-library/react'
 import PlantCard from '../PlantCard'
 
 describe('PlantCard', () => {
-  it('renders plant details', () => {
+  it('renders plant details with hydration progress and tasks badge', () => {
     render(
       <PlantCard
         nickname="Fern"
         species="Pteridophyta"
         status="Healthy"
         hydration={55.4}
+        tasksDue={3}
         note="Needs sun"
       />
     )
+
+    const progress = screen.getByRole('progressbar')
+    expect(progress).toHaveAttribute('aria-valuenow', '55')
+    expect(progress).toHaveAttribute('aria-valuemin', '0')
+    expect(progress).toHaveAttribute('aria-valuemax', '100')
 
     expect(screen.getByText(/fern/i)).toBeInTheDocument()
     expect(screen.getByText(/pteridophyta/i)).toBeInTheDocument()
     expect(screen.getByText(/healthy/i)).toBeInTheDocument()
     expect(screen.getByText(/needs sun/i)).toBeInTheDocument()
     expect(screen.getByText(/Hydration: 55%/i)).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
   })
 })

--- a/components/__tests__/RoomCard.test.tsx
+++ b/components/__tests__/RoomCard.test.tsx
@@ -2,11 +2,16 @@ import { render, screen } from '@testing-library/react'
 import RoomCard from '../RoomCard'
 
 describe('RoomCard', () => {
-  it('renders room info', () => {
+  it('renders room info with hydration progress and tasks badge', () => {
     render(<RoomCard name="Living Room" avgHydration={70.2} tasksDue={3} />)
+
+    const progress = screen.getByRole('progressbar')
+    expect(progress).toHaveAttribute('aria-valuenow', '70')
+    expect(progress).toHaveAttribute('aria-valuemin', '0')
+    expect(progress).toHaveAttribute('aria-valuemax', '100')
 
     expect(screen.getByText(/living room/i)).toBeInTheDocument()
     expect(screen.getByText(/Avg Hydration: 70%/i)).toBeInTheDocument()
-    expect(screen.getByText(/3 tasks due/i)).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
   })
 })

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom'
+
+// jsdom doesn't implement matchMedia, so we provide a basic stub
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })
+}


### PR DESCRIPTION
## Summary
- Show hydration with accessible progress bars and color-coded states in plant and room cards
- Display due task counts as badges alongside hydration info
- Polyfill `matchMedia` in tests for consistent environment

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4518917708324afb2e509b36939cb