### PR TITLE
Improve dashboard grid responsiveness

### DIFF
--- a/app/(dashboard)/__tests__/page.test.tsx
+++ b/app/(dashboard)/__tests__/page.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react'
+import TodayPage from '../page'
+
+describe('Dashboard page layout', () => {
+  it('uses responsive grid and centered container', () => {
+    const { container } = render(<TodayPage />)
+    const wrapper = container.querySelector('main > div')
+    expect(wrapper).toHaveClass('max-w-7xl')
+    expect(wrapper).toHaveClass('mx-auto')
+
+    const grid = container.querySelector('section')
+    expect(grid).toHaveClass('grid-cols-1')
+    expect(grid).toHaveClass('md:grid-cols-2')
+    expect(grid).toHaveClass('lg:grid-cols-3')
+    expect(grid).toHaveClass('xl:grid-cols-4')
+  })
+})

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -28,33 +28,35 @@ export default function TodayPage() {
     <>
       <Header plantsCount={plantsCount} avgHydration={avgHydration} tasksDue={tasksDue} />
       <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6">
-        <header className="sticky top-0 z-10 backdrop-blur bg-white/70 dark:bg-gray-900/70 p-2 flex items-center justify-between md:hidden">
-          <span className="font-medium">Today</span>
-          <button className="p-2 rounded-full bg-green-500 text-white">＋</button>
-        </header>
+        <div className="max-w-7xl mx-auto">
+          <header className="sticky top-0 z-10 backdrop-blur bg-white/70 dark:bg-gray-900/70 p-2 flex items-center justify-between md:hidden">
+            <span className="font-medium">Today</span>
+            <button className="p-2 rounded-full bg-green-500 text-white">＋</button>
+          </header>
 
-        <header className="mt-4 mb-4 hidden md:block">
-          <h2 className="text-xl font-bold">Today</h2>
-          <p className="text-sm text-gray-500">
-            {plantsCount} plants · Avg hydration {avgHydration}% · {tasksDue} tasks due today
-          </p>
-        </header>
+          <header className="mt-4 mb-4 hidden md:block">
+            <h2 className="text-xl font-bold">Today</h2>
+            <p className="text-sm text-gray-500">
+              {plantsCount} plants · Avg hydration {avgHydration}% · {tasksDue} tasks due today
+            </p>
+          </header>
 
-        <section className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-          {plants.map((p) => (
-            <Link key={p.id} href={`/plants/${p.id}`} className="block">
-              <PlantCard
-                nickname={p.nickname}
-                species={p.species}
-                status={p.status}
-                hydration={p.hydration}
-                note={p.note}
-              />
-            </Link>
-          ))}
-        </section>
+          <section className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {plants.map((p) => (
+              <Link key={p.id} href={`/plants/${p.id}`} className="block">
+                <PlantCard
+                  nickname={p.nickname}
+                  species={p.species}
+                  status={p.status}
+                  hydration={p.hydration}
+                  note={p.note}
+                />
+              </Link>
+            ))}
+          </section>
 
-        <Footer />
+          <Footer />
+        </div>
       </main>
     </>
   )


### PR DESCRIPTION
## Summary
- add `max-w-7xl mx-auto` wrapper to dashboard content
- extend grid to `lg:grid-cols-3` and `xl:grid-cols-4`
- test responsive grid and container

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68b45351f3988324a10b1ef7d9079a7f