### PR TITLE
Improve navigation accessibility with ARIA attributes

### DIFF
--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -14,7 +14,11 @@ export default function MobileNav() {
   const pathname = usePathname()
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex justify-around py-2 text-xs">
+    <nav
+      className="fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex justify-around py-2 text-xs"
+      role="navigation"
+      aria-label="Mobile navigation"
+    >
       {navItems.map(({ href, label, icon: Icon }) => {
         const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
         return (
@@ -22,8 +26,10 @@ export default function MobileNav() {
             key={href}
             href={href}
             className={`flex flex-col items-center gap-1 px-3 py-1 ${active ? "text-flora-leaf" : "text-gray-700 dark:text-gray-200"}`}
+            aria-current={active ? "page" : undefined}
+            aria-label={label}
           >
-            <Icon className="h-5 w-5" />
+            <Icon className="h-5 w-5" aria-hidden="true" />
             <span>{label}</span>
           </Link>
         )

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -15,7 +15,11 @@ export default function SidebarNav() {
   return (
     <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
       <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
-      <nav className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200">
+      <nav
+        className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200"
+        role="navigation"
+        aria-label="Sidebar navigation"
+      >
         {navItems.map(({ href, label }) => {
           const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
           return (
@@ -23,6 +27,8 @@ export default function SidebarNav() {
               key={href}
               href={href}
               className={`block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${active ? "bg-gray-100 dark:bg-gray-800 text-flora-leaf" : ""}`}
+              aria-current={active ? "page" : undefined}
+              aria-label={label}
             >
               {label}
             </Link>


### PR DESCRIPTION
## Summary
- mark active links with `aria-current="page"`
- add `role="navigation"` and labels to nav containers
- include descriptive `aria-label`s and hide decorative icons

## Testing
- `pnpm test`
- `pnpm lint` *(fails: asks for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b45705ae248324808cfa1b89f4fea8