### PR TITLE
Add spacing and typography tokens

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -20,14 +20,14 @@ const plants: Plant[] = [
 
 export default function TodayPage() {
   return (
-    <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6">
+    <main className="flex-1 p-4 md:p-6 pb-18 md:pb-6">
       <header className="sticky top-0 z-10 backdrop-blur bg-white/70 dark:bg-gray-900/70 p-2 flex items-center justify-between md:hidden">
         <span className="font-medium">Today</span>
         <button className="p-2 rounded-full bg-green-500 text-white">＋</button>
       </header>
 
-      <header className="mt-4 mb-4 hidden md:block">
-        <h2 className="text-xl font-bold">Today</h2>
+      <header className="mt-13 mb-13 hidden md:block">
+        <h2 className="text-xl font-heading font-bold">Today</h2>
         <p className="text-sm text-gray-500">4 plants · Avg hydration 72% · 2 tasks due today</p>
       </header>
 

--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
 
   return (
     <main className="flex-1 bg-white dark:bg-gray-900">
-      <div className="p-6 space-y-6">
+      <div className="p-13 space-y-13">
         <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
           ← Back to Today
         </Link>
@@ -76,7 +76,7 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
                 className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
               />
               <div className="space-y-2 md:w-1/2 text-center md:text-left">
-                <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
+                <h1 className="text-3xl font-heading font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
                 <p className="italic text-gray-500">{plant.species}</p>
                 <div className="flex flex-wrap justify-center md:justify-start gap-2 text-sm">
                   <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">{plant.status}</span>
@@ -106,7 +106,7 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
             </section>
 
             <section>
-              <h2 className="text-lg font-semibold mb-3">Timeline</h2>
+              <h2 className="text-lg font-heading font-semibold mb-13">Timeline</h2>
               <ul className="space-y-2">
                 {plant.events.map((e) => (
                   <li
@@ -127,7 +127,7 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
             </section>
 
             <section>
-              <h2 className="text-lg font-semibold mb-3">Gallery</h2>
+              <h2 className="text-lg font-heading font-semibold mb-13">Gallery</h2>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                 {plant.photos.map((src, i) => (
                   <img

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import "./globals.css"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
+import { Inter, Merriweather } from "next/font/google"
 import PageTransition from "../components/PageTransition"
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" })
+const merriweather = Merriweather({ subsets: ["latin"], variable: "--font-heading" })
 
 export const metadata: Metadata = {
   title: "Flora-Science",
@@ -20,7 +21,9 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.ico" />
       </head>
-      <body className={`${inter.className} bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`}>
+      <body
+        className={`${inter.variable} ${merriweather.variable} font-sans bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`}
+      >
         <PageTransition>{children}</PageTransition>
       </body>
     </html>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ type FooterProps = {
 export default function Footer({ lastSync }: FooterProps) {
   const syncTime = lastSync ?? getLastSync()
   return (
-    <footer className="mt-6 text-xs text-gray-500">
+    <footer className="mt-13 text-xs text-gray-500">
       Last sync: {syncTime}
     </footer>
   )

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -13,8 +13,8 @@ export default function SidebarNav() {
   const pathname = usePathname()
 
   return (
-    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
-      <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
+    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-13">
+      <h2 className="font-heading text-lg mb-13 text-flora-leaf">Flora-Science</h2>
       <nav className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200">
         {navItems.map(({ href, label }) => {
           const active = href === "/" ? pathname === "/" : pathname.startsWith(href)

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,0 +1,23 @@
+# Design Tokens
+
+Flora-Science centralizes visual decisions in Tailwind's theme.
+
+## Spacing
+
+| Token | Value |
+|-------|-------|
+| `13`  | `3.25rem` |
+| `18`  | `4.5rem`  |
+
+Use these via Tailwind utilities, e.g. `p-13` or `mb-18`.
+
+## Typography
+
+| Token       | Font family |
+|-------------|-------------|
+| `font-sans` | Inter, system sans-serif |
+| `font-heading` | Merriweather, serif |
+
+Apply font families with `font-sans` and `font-heading` classes.
+
+All new components should rely on these tokens instead of hard-coded values to ensure consistent spacing and type across the app.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,6 +28,16 @@ const config: Config = {
         lg: "1.125rem",
         xl: "1.25rem",
         "2xl": "1.5rem",
+        h1: "2rem",
+        h2: "1.5rem",
+      },
+      spacing: {
+        "13": "3.25rem",
+        "18": "4.5rem",
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", "sans-serif"],
+        heading: ["var(--font-heading)", "serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend Tailwind theme with spacing and font family design tokens
- replace hard-coded spacing and fonts in layout, pages, and components
- document token usage in `docs/tokens.md`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b4533a68d0832497f84fa65f53feba