### PR TITLE
feat: add flexible environment row

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -1,7 +1,9 @@
 import { TempHumidityChart, VPDGauge } from "@/components/Charts"
+import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
 
 export default function SciencePanel() {
+  const readings = { temperature: 75, humidity: 52, vpd: 1.2 }
   return (
     <main className="flex-1 p-6">
       <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
@@ -11,6 +13,11 @@ export default function SciencePanel() {
 
       <section className="mt-6">
         <h3 className="font-medium text-gray-800">Environment Data</h3>
+        <EnvRow
+          temperature={readings.temperature}
+          humidity={readings.humidity}
+          vpd={readings.vpd}
+        />
         <TempHumidityChart />
       </section>
 

--- a/components/EnvRow.tsx
+++ b/components/EnvRow.tsx
@@ -1,16 +1,32 @@
 import { Thermometer, Droplets, Wind } from "lucide-react"
+import { formatHumidity, formatTemperature, formatVpd } from "@/lib/utils"
 
-export default function EnvRow() {
+type EnvRowProps = {
+  temperature: number
+  humidity: number
+  vpd: number
+  tempUnit?: 'F' | 'C'
+}
+
+export default function EnvRow({
+  temperature,
+  humidity,
+  vpd,
+  tempUnit = 'F',
+}: EnvRowProps) {
   return (
     <div className="mt-4 flex gap-6 text-sm items-center">
       <span className="flex items-center gap-1">
-        <Thermometer className="w-4 h-4 text-red-500" /> 75°F
+        <Thermometer className="w-4 h-4 text-red-500" />
+        {formatTemperature(temperature, tempUnit)}
       </span>
       <span className="flex items-center gap-1">
-        <Droplets className="w-4 h-4 text-blue-500" /> 52% RH
+        <Droplets className="w-4 h-4 text-blue-500" />
+        {formatHumidity(humidity)}
       </span>
       <span className="flex items-center gap-1">
-        <Wind className="w-4 h-4 text-indigo-500" /> 1.2 kPa
+        <Wind className="w-4 h-4 text-indigo-500" />
+        {formatVpd(vpd)}
       </span>
     </div>
   )

--- a/components/__tests__/EnvRow.test.tsx
+++ b/components/__tests__/EnvRow.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import EnvRow from '../EnvRow'
+
+describe('EnvRow', () => {
+  it('renders formatted environment readings', () => {
+    render(<EnvRow temperature={75} humidity={52} vpd={1.2} />)
+    expect(screen.getByText('75.0°F')).toBeInTheDocument()
+    expect(screen.getByText('52% RH')).toBeInTheDocument()
+    expect(screen.getByText('1.2 kPa')).toBeInTheDocument()
+  })
+})
+

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,4 +6,20 @@ export function getLastSync(): string {
   })
 }
 
+export function formatTemperature(
+  tempF: number,
+  unit: 'F' | 'C' = 'F'
+): string {
+  const value = unit === 'F' ? tempF : ((tempF - 32) * 5) / 9
+  return `${value.toFixed(1)}°${unit}`
+}
+
+export function formatHumidity(rh: number): string {
+  return `${rh.toFixed(0)}% RH`
+}
+
+export function formatVpd(vpd: number, unit = 'kPa'): string {
+  return `${vpd.toFixed(1)} ${unit}`
+}
+
 // TODO: Wire to real sync events once data persistence is available.


### PR DESCRIPTION
## Summary
- allow EnvRow to display passed temperature, humidity, and VPD readings
- show current environment data on SciencePanel
- add formatting helpers and unit tests

## Testing
- `pnpm test`
- `pnpm lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b457fee5c88324a9dc046d322f1abf