### PR TITLE
refactor notebook entry icon usage

### DIFF
--- a/app/(dashboard)/notebook/page.tsx
+++ b/app/(dashboard)/notebook/page.tsx
@@ -1,4 +1,5 @@
 import NotebookEntry from "@/components/NotebookEntry"
+import { Sprout } from "lucide-react"
 
 export default function NotebookPage() {
   return (
@@ -14,12 +15,12 @@ export default function NotebookPage() {
 
       <div className="mt-6 space-y-4">
         <NotebookEntry
-          icon="🌱"
+          icon={<Sprout className="h-4 w-4" />}
           note="Observation: New leaf unfurled on Delilah (*Monstera deliciosa*)"
           date="Aug 28, 2025"
         />
         <NotebookEntry
-          icon="🐛"
+          icon={<span>🐛</span>}
           note="Pest check on Sunny (*Sansevieria trifasciata*) — none found"
           date="Aug 27, 2025"
         />

--- a/components/NotebookEntry.tsx
+++ b/components/NotebookEntry.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from "react"
+
 type Props = {
-  icon: string
+  icon: ReactNode
   note: string
   date: string
 }
@@ -7,7 +9,12 @@ type Props = {
 export default function NotebookEntry({ icon, note, date }: Props) {
   return (
     <div className="p-4 border rounded-lg">
-      <p className="text-sm">{icon} {note}</p>
+      <p className="text-sm">
+        <span aria-hidden className="mr-1">
+          {icon}
+        </span>
+        {note}
+      </p>
       <p className="text-xs text-gray-500">{date}</p>
     </div>
   )


### PR DESCRIPTION
## Summary
- allow NotebookEntry to accept ReactNode icons with dedicated span and aria-hidden
- update notebook page to send icons as components or wrapped emojis

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68b459ec162083248a0160b07a0b2584