### PR TITLE
Add temperature unit toggle to science panel

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -1,14 +1,26 @@
+"use client"
+
+import { useState } from "react"
 import { TempHumidityChart, VPDGauge } from "@/components/Charts"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
 
 export default function SciencePanel() {
   const readings = { temperature: 75, humidity: 52, vpd: 1.2 }
+  const [tempUnit, setTempUnit] = useState<"F" | "C">("F")
+
+  const toggleUnit = () => setTempUnit((u) => (u === "F" ? "C" : "F"))
+
   return (
     <main className="flex-1 p-6">
       <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
         <h2 className="font-semibold text-xl">Science Panel</h2>
-        <button className="px-3 py-1 border rounded hover:bg-gray-100">°F / °C</button>
+        <button
+          onClick={toggleUnit}
+          className="px-3 py-1 border rounded hover:bg-gray-100"
+        >
+          {tempUnit === "F" ? "°F / °C" : "°C / °F"}
+        </button>
       </header>
 
       <section className="mt-6">
@@ -17,8 +29,9 @@ export default function SciencePanel() {
           temperature={readings.temperature}
           humidity={readings.humidity}
           vpd={readings.vpd}
+          tempUnit={tempUnit}
         />
-        <TempHumidityChart />
+        <TempHumidityChart tempUnit={tempUnit} />
       </section>
 
       <section className="mt-6">

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -16,16 +16,33 @@ const envData = [
   { day: "Sun", temp: 75, rh: 56 },
 ]
 
-export function TempHumidityChart() {
+export function TempHumidityChart({
+  tempUnit = "F",
+}: {
+  tempUnit?: "F" | "C"
+}) {
+  const data =
+    tempUnit === "F"
+      ? envData
+      : envData.map((d) => ({
+          ...d,
+          temp: ((d.temp - 32) * 5) / 9,
+        }))
+
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <LineChart data={envData}>
+      <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="day" />
         <YAxis />
         <Tooltip />
         <Legend />
-        <Line type="monotone" dataKey="temp" stroke="#f87171" name="Temp (°F)" />
+        <Line
+          type="monotone"
+          dataKey="temp"
+          stroke="#f87171"
+          name={tempUnit === "F" ? "Temp (°F)" : "Temp (°C)"}
+        />
         <Line type="monotone" dataKey="rh" stroke="#60a5fa" name="RH (%)" />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- add temperature unit state to science panel and toggle button
- convert chart data based on selected unit
- pass selected unit to EnvRow and charts for dynamic rendering

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b45cf694ac83249b39c9c08ac821be