### PR TITLE
Add hydration progress bar to plant detail view

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { useEffect, useState } from "react"
+import { getHydrationProgress } from "@/components/PlantCard"
 
 interface PlantEvent {
   id: number
@@ -24,6 +25,7 @@ interface Plant {
 export default function PlantDetailPage({ params }: { params: { id: string } }) {
   const [plant, setPlant] = useState<Plant | null>(null)
   const [loading, setLoading] = useState(true)
+  const progress = getHydrationProgress(plant?.hydration ?? 0)
 
   useEffect(() => {
     async function loadPlant() {
@@ -73,7 +75,20 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
                 <p className="italic text-gray-500">{plant.species}</p>
                 <div className="flex flex-wrap justify-center md:justify-start gap-2 text-sm">
                   <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">{plant.status}</span>
-                  <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">Hydration: {plant.hydration}%</span>
+                </div>
+                <div
+                  className="w-full bg-gray-200 rounded-full h-2"
+                  role="progressbar"
+                  aria-label="Hydration"
+                  aria-valuenow={progress.pct}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                >
+                  <div
+                    className={`h-2 rounded-full ${progress.barColor}`}
+                    style={{ width: `${progress.pct}%` }}
+                  />
+                  <span className="sr-only">Hydration: {progress.pct}%</span>
                 </div>
                 <p className="text-sm text-gray-500 dark:text-gray-400">
                   Last watered: <strong>{plant.lastWatered}</strong> · Next due: <strong>{plant.nextDue}</strong>

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -7,6 +7,12 @@ type PlantCardProps = {
   note?: string
 }
 
+export function getHydrationProgress(hydration: number) {
+  const pct = Math.max(0, Math.min(100, Math.round(hydration)))
+  const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
+  return { pct, barColor }
+}
+
 export default function PlantCard({
   nickname,
   species,
@@ -15,9 +21,7 @@ export default function PlantCard({
   tasksDue = 0,
   note,
 }: PlantCardProps) {
-  // simple % formatting guard
-  const pct = Math.max(0, Math.min(100, Math.round(hydration)))
-  const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
+  const { pct, barColor } = getHydrationProgress(hydration)
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
 
   return (


### PR DESCRIPTION
## Summary
- export reusable `getHydrationProgress` helper from `PlantCard`
- show hydration level on plant detail page with color-coded progress bar and screen-reader text

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46764e9088324b202d37eb3256718