### PR TITLE
Improve room grid layout and card heights

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -55,7 +55,7 @@ export default function RoomsPage() {
           </Link>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rooms
             .filter((r) => r.name.toLowerCase().includes(searchTerm.toLowerCase()))
             .map((r) => (

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -9,7 +9,7 @@ export default function RoomCard({ name, avgHydration, tasksDue }: RoomCardProps
   const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
   return (
-    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
+    <div className="h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
       <h3 className="font-semibold text-gray-900 dark:text-gray-100">{name}</h3>
       <div
         className="w-full bg-gray-200 rounded-full h-2 mt-2"


### PR DESCRIPTION
## Summary
- expand rooms grid to three columns on large screens and increase spacing
- ensure RoomCard components stretch uniformly with flex layout

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b46e262540832486b1b17058704c23