### PR TITLE
Add sort options for rooms dashboard

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -7,10 +7,13 @@ import { getLastSync } from "@/lib/utils"
 import { getRooms, type Room } from "@/lib/api"
 
 export default function RoomsPage() {
+  type SortBy = "name" | "hydration" | "tasks"
+
   const [rooms, setRooms] = useState<Room[]>([])
   const [searchTerm, setSearchTerm] = useState("")
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [sortBy, setSortBy] = useState<SortBy>("name")
 
   useEffect(() => {
     async function loadRooms() {
@@ -26,6 +29,17 @@ export default function RoomsPage() {
     loadRooms()
   }, [])
 
+  const sortedRooms = [...rooms].sort((a, b) => {
+    switch (sortBy) {
+      case "hydration":
+        return b.avgHydration - a.avgHydration
+      case "tasks":
+        return b.tasksDue - a.tasksDue
+      default:
+        return a.name.localeCompare(b.name)
+    }
+  })
+
   return (
     <main className="flex-1 p-6">
       <div className="mb-4 flex items-center justify-between">
@@ -35,13 +49,24 @@ export default function RoomsPage() {
         </Link>
       </div>
 
-      <input
-        type="text"
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
-        placeholder="Search rooms…"
-        className="mb-4 p-2 border rounded w-full"
-      />
+      <div className="mb-4 flex gap-2">
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Search rooms…"
+          className="p-2 border rounded flex-1"
+        />
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortBy)}
+          className="p-2 border rounded"
+        >
+          <option value="name">Name</option>
+          <option value="hydration">Hydration</option>
+          <option value="tasks">Tasks</option>
+        </select>
+      </div>
 
       {loading ? (
         <p>Loading rooms...</p>
@@ -56,7 +81,7 @@ export default function RoomsPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {rooms
+          {sortedRooms
             .filter((r) => r.name.toLowerCase().includes(searchTerm.toLowerCase()))
             .map((r) => (
               <Link key={r.id} href={`/rooms/${r.id}`} className="block">


### PR DESCRIPTION
## Summary
- allow sorting rooms by name, hydration, or tasks
- add dropdown to choose sort order

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46eae7b9c83249fb7d5d8782a2fe2