### PR TITLE
Add room skeleton placeholders for loading state

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { useState, useEffect } from "react"
 import RoomCard from "@/components/RoomCard"
+import RoomSkeleton from "@/components/RoomSkeleton"
 import { getLastSync } from "@/lib/utils"
 import { getRooms, type Room } from "@/lib/api"
 
@@ -11,19 +12,20 @@ export default function RoomsPage() {
 
   const [rooms, setRooms] = useState<Room[]>([])
   const [searchTerm, setSearchTerm] = useState("")
-  const [loading, setLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [sortBy, setSortBy] = useState<SortBy>("name")
 
   useEffect(() => {
     async function loadRooms() {
+      setIsLoading(true)
       try {
         const data = await getRooms()
         setRooms(data)
       } catch (err) {
         setError("Failed to load rooms")
       } finally {
-        setLoading(false)
+        setIsLoading(false)
       }
     }
     loadRooms()
@@ -68,8 +70,12 @@ export default function RoomsPage() {
         </select>
       </div>
 
-      {loading ? (
-        <p>Loading rooms...</p>
+      {isLoading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <RoomSkeleton key={i} />
+          ))}
+        </div>
       ) : error ? (
         <p className="text-red-500">{error}</p>
       ) : rooms.length === 0 ? (

--- a/components/RoomSkeleton.tsx
+++ b/components/RoomSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+
+export default function RoomSkeleton() {
+  return (
+    <div className="h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm bg-white dark:bg-gray-800 animate-pulse">
+      <div className="h-5 w-1/2 bg-gray-200 dark:bg-gray-700 rounded" />
+      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 mt-2">
+        <div className="h-2 bg-gray-300 dark:bg-gray-600 rounded-full w-1/3" />
+      </div>
+      <div className="flex items-center justify-between mt-2">
+        <div className="h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="flex items-center gap-1">
+          <div className="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-6 bg-gray-200 dark:bg-gray-700 rounded-full" />
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `RoomSkeleton` component with gray placeholders
- show multiple room skeletons while fetching rooms
- track `isLoading` state during rooms fetch

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47128329c8324b3afdf06e3c1aa60