### PR TITLE
Use Next.js Image component for plant views

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from "next/link"
+import Image from "next/image"
 import { useEffect, useState } from "react"
 import Lightbox from "@/components/Lightbox"
 import { Droplet, Sprout, FileText } from "lucide-react"
@@ -98,10 +99,14 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
         ) : (
           <>
             <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
-              <img
+              <Image
                 src={plant.photos[0]}
                 alt={plant.nickname}
+                width={800}
+                height={600}
+                sizes="(max-width: 768px) 100vw, 50vw"
                 className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
+                loading="lazy"
               />
               <div className="space-y-2 md:w-1/2 text-center md:text-left">
                 <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from "react"
+import Image from "next/image"
 
 interface LightboxImage {
   src: string
@@ -65,10 +66,14 @@ export default function Lightbox({ images }: { images: LightboxImage[] }) {
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/75"
         >
           <div className="relative">
-            <img
+            <Image
               src={images[openIndex].src}
               alt={images[openIndex].alt}
+              width={1200}
+              height={800}
+              sizes="100vw"
               className="max-h-screen max-w-full object-contain"
+              loading="lazy"
             />
             <button
               ref={closeRef}
@@ -110,10 +115,14 @@ export default function Lightbox({ images }: { images: LightboxImage[] }) {
             aria-label={`View image ${index + 1} of ${images.length}`}
             className="focus:outline-none"
           >
-            <img
+            <Image
               src={img.src}
               alt={img.alt}
+              width={400}
+              height={400}
+              sizes="(max-width: 768px) 50vw, 25vw"
               className="aspect-square rounded-lg border object-cover transition-transform duration-300 hover:scale-105 dark:border-gray-700"
+              loading="lazy"
             />
           </button>
         ))}


### PR DESCRIPTION
## Summary
- switch plant detail hero photo to `next/image` with responsive sizing and lazy loading
- upgrade Lightbox thumbnails and full view to `next/image`

## Testing
- `pnpm lint` *(warn: React Hook useEffect has missing dependencies: 'showNext' and 'showPrev')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b472434c9c8324906ef2e59eef4f30