### PR TITLE
Add modals for plant actions

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -7,6 +7,9 @@ import Lightbox from "@/components/Lightbox"
 import { Droplet, Sprout, FileText } from "lucide-react"
 import { getHydrationProgress } from "@/components/PlantCard"
 import PlantDetailSkeleton from "./PlantDetailSkeleton"
+import WaterModal from "@/components/WaterModal"
+import FertilizeModal from "@/components/FertilizeModal"
+import NoteModal from "@/components/NoteModal"
 
 interface PlantEvent {
   id: number
@@ -48,20 +51,20 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
   const [plant, setPlant] = useState<Plant | null>(null)
   const [loading, setLoading] = useState(true)
   const progress = getHydrationProgress(plant?.hydration ?? 0)
+  const [waterOpen, setWaterOpen] = useState(false)
+  const [fertilizeOpen, setFertilizeOpen] = useState(false)
+  const [noteOpen, setNoteOpen] = useState(false)
 
   function handleWater() {
-    alert("Water plant")
+    setWaterOpen(true)
   }
 
   function handleFertilize() {
-    alert("Fertilize plant")
+    setFertilizeOpen(true)
   }
 
   function handleAddNote() {
-    const note = prompt("Add a note for this plant:")
-    if (note) {
-      alert(`Note added: ${note}`)
-    }
+    setNoteOpen(true)
   }
 
   useEffect(() => {
@@ -217,6 +220,21 @@ export default function PlantDetailPage({ params }: { params: { id: string } }) 
           </>
         )}
       </div>
+      <WaterModal
+        isOpen={waterOpen}
+        onClose={() => setWaterOpen(false)}
+        onSubmit={(amount) => alert(`Watered: ${amount}ml`)}
+      />
+      <FertilizeModal
+        isOpen={fertilizeOpen}
+        onClose={() => setFertilizeOpen(false)}
+        onSubmit={(type) => alert(`Fertilized with ${type}`)}
+      />
+      <NoteModal
+        isOpen={noteOpen}
+        onClose={() => setNoteOpen(false)}
+        onSubmit={(note) => alert(`Note added: ${note}`)}
+      />
     </main>
   )
 }

--- a/components/FertilizeModal.tsx
+++ b/components/FertilizeModal.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+import Modal from './Modal'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (type: string) => void
+}
+
+export default function FertilizeModal({ isOpen, onClose, onSubmit }: Props) {
+  const [type, setType] = useState('')
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    onSubmit(type)
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">Fertilize Plant</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="block text-sm">
+          Fertilizer
+          <input
+            type="text"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="mt-1 w-full rounded border px-2 py-1"
+            autoFocus
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 rounded border"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700"
+          >
+            Confirm
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export default function Modal({ isOpen, onClose, children }: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (!dialogRef.current) return
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      } else if (e.key === 'Tab') {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+        )
+        if (focusable.length === 0) return
+        const list = Array.from(focusable)
+        const index = list.indexOf(document.activeElement as HTMLElement)
+        const nextIndex = e.shiftKey
+          ? (index - 1 + list.length) % list.length
+          : (index + 1) % list.length
+        e.preventDefault()
+        list[nextIndex]?.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    const first = dialogRef.current.querySelector<HTMLElement>(
+      'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+    )
+    first?.focus()
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        ref={dialogRef}
+        className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg max-w-sm w-full"
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+

--- a/components/NoteModal.tsx
+++ b/components/NoteModal.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import Modal from './Modal'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (note: string) => void
+}
+
+export default function NoteModal({ isOpen, onClose, onSubmit }: Props) {
+  const [note, setNote] = useState('')
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    onSubmit(note)
+    onClose()
+    setNote('')
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">Add Note</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="block text-sm">
+          Note
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="mt-1 w-full rounded border px-2 py-1"
+            rows={4}
+            autoFocus
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 rounded border"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-3 py-1 rounded bg-purple-600 text-white hover:bg-purple-700"
+          >
+            Confirm
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+

--- a/components/WaterModal.tsx
+++ b/components/WaterModal.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+import Modal from './Modal'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (amount: string) => void
+}
+
+export default function WaterModal({ isOpen, onClose, onSubmit }: Props) {
+  const [amount, setAmount] = useState('')
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    onSubmit(amount)
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">Water Plant</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="block text-sm">
+          Amount (ml)
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="mt-1 w-full rounded border px-2 py-1"
+            autoFocus
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 rounded border"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Confirm
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+


### PR DESCRIPTION
## Summary
- introduce reusable Modal component with focus trapping
- add WaterModal, FertilizeModal, and NoteModal with simple forms
- replace alert/prompt logic with modals on plant detail page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b472d5005483249569cc914694d346