### PR TITLE
Add tag filtering for rooms

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -17,6 +17,7 @@ export default function RoomsPage() {
   const [error, setError] = useState<string | null>(null)
   const [sortBy, setSortBy] = useState<SortBy>("name")
   const [view, setView] = useState<"grid" | "list">("grid")
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
 
   useEffect(() => {
     async function loadRooms() {
@@ -44,9 +45,20 @@ export default function RoomsPage() {
     }
   })
 
-  const filteredRooms = sortedRooms.filter((r) =>
-    r.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredRooms = sortedRooms.filter(
+    (r) =>
+      r.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+      (selectedTags.length === 0 ||
+        selectedTags.every((tag) => r.tags.includes(tag)))
   )
+
+  const allTags = Array.from(new Set(rooms.flatMap((r) => r.tags))).sort()
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    )
+  }
 
   return (
     <main className="flex-1 p-6">
@@ -92,6 +104,20 @@ export default function RoomsPage() {
         </div>
       </div>
 
+      {allTags.length > 0 && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              onClick={() => toggleTag(tag)}
+              className={`px-2 py-1 rounded-full text-xs border ${selectedTags.includes(tag) ? 'bg-flora-leaf text-white border-flora-leaf' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-600'}`}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      )}
+
       {isLoading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {Array.from({ length: 6 }).map((_, i) => (
@@ -115,6 +141,7 @@ export default function RoomsPage() {
                 name={r.name}
                 avgHydration={r.avgHydration}
                 tasksDue={r.tasksDue}
+                tags={r.tags}
               />
             </Link>
           ))}

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -1,9 +1,27 @@
 import { NextResponse } from 'next/server'
 
 const sampleRooms = [
-  { id: 'living-room', name: 'Living Room', avgHydration: 72, tasksDue: 2 },
-  { id: 'bedroom', name: 'Bedroom', avgHydration: 65, tasksDue: 1 },
-  { id: 'office', name: 'Office', avgHydration: 82, tasksDue: 0 }
+  {
+    id: 'living-room',
+    name: 'Living Room',
+    avgHydration: 72,
+    tasksDue: 2,
+    tags: ['indoor', 'bright']
+  },
+  {
+    id: 'bedroom',
+    name: 'Bedroom',
+    avgHydration: 65,
+    tasksDue: 1,
+    tags: ['indoor', 'low-light']
+  },
+  {
+    id: 'office',
+    name: 'Office',
+    avgHydration: 82,
+    tasksDue: 0,
+    tags: ['indoor', 'workspace']
+  }
 ]
 
 export async function GET() {

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -2,15 +2,28 @@ type RoomCardProps = {
   name: string
   avgHydration: number
   tasksDue: number
+  tags: string[]
 }
 
-export default function RoomCard({ name, avgHydration, tasksDue }: RoomCardProps) {
+export default function RoomCard({ name, avgHydration, tasksDue, tags }: RoomCardProps) {
   const pct = Math.max(0, Math.min(100, Math.round(avgHydration)))
   const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
   return (
     <div className="h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
       <h3 className="font-semibold text-gray-900 dark:text-gray-100">{name}</h3>
+      {tags.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {tags.map((tag) => (
+            <span
+              key={tag}
+              className="px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
       <div
         className="w-full bg-gray-200 rounded-full h-2 mt-2"
         role="progressbar"

--- a/components/RoomSkeleton.tsx
+++ b/components/RoomSkeleton.tsx
@@ -4,6 +4,10 @@ export default function RoomSkeleton() {
   return (
     <div className="h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm bg-white dark:bg-gray-800 animate-pulse">
       <div className="h-5 w-1/2 bg-gray-200 dark:bg-gray-700 rounded" />
+      <div className="flex gap-1 mt-1">
+        <div className="h-4 w-10 bg-gray-200 dark:bg-gray-700 rounded-full" />
+        <div className="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded-full" />
+      </div>
       <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 mt-2">
         <div className="h-2 bg-gray-300 dark:bg-gray-600 rounded-full w-1/3" />
       </div>

--- a/components/__tests__/RoomCard.test.tsx
+++ b/components/__tests__/RoomCard.test.tsx
@@ -3,7 +3,14 @@ import RoomCard from '../RoomCard'
 
 describe('RoomCard', () => {
   it('renders room info with hydration progress and tasks badge', () => {
-    render(<RoomCard name="Living Room" avgHydration={70.2} tasksDue={3} />)
+    render(
+      <RoomCard
+        name="Living Room"
+        avgHydration={70.2}
+        tasksDue={3}
+        tags={['indoor', 'bright']}
+      />
+    )
 
     const progress = screen.getByRole('progressbar')
     expect(progress).toHaveAttribute('aria-valuenow', '70')
@@ -13,5 +20,7 @@ describe('RoomCard', () => {
     expect(screen.getByText(/living room/i)).toBeInTheDocument()
     expect(screen.getByText(/Avg Hydration: 70%/i)).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('indoor')).toBeInTheDocument()
+    expect(screen.getByText('bright')).toBeInTheDocument()
   })
 })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,6 +3,7 @@ export type Room = {
   name: string
   avgHydration: number
   tasksDue: number
+  tags: string[]
 }
 
 export async function getRooms(): Promise<Room[]> {


### PR DESCRIPTION
## Summary
- add `tags` to room model and sample API data
- show tags on room cards and compute tag filter chips
- filter room list by selected tags and cover with tests

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b47297847083249be776e9daa6e5ac