### PR TITLE
Add room modal and active room handling

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react"
 import { LayoutGrid, List } from "lucide-react"
 import RoomCard from "@/components/RoomCard"
 import RoomSkeleton from "@/components/RoomSkeleton"
+import RoomModal from "@/components/RoomModal"
 import { getLastSync } from "@/lib/utils"
 import { getRooms, type Room } from "@/lib/api"
 
@@ -18,6 +19,7 @@ export default function RoomsPage() {
   const [sortBy, setSortBy] = useState<SortBy>("name")
   const [view, setView] = useState<"grid" | "list">("grid")
   const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [activeRoom, setActiveRoom] = useState<Room | null>(null)
 
   useEffect(() => {
     async function loadRooms() {
@@ -136,14 +138,14 @@ export default function RoomsPage() {
       ) : view === "grid" ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredRooms.map((r) => (
-            <Link key={r.id} href={`/rooms/${r.id}`} className="block">
-              <RoomCard
-                name={r.name}
-                avgHydration={r.avgHydration}
-                tasksDue={r.tasksDue}
-                tags={r.tags}
-              />
-            </Link>
+            <RoomCard
+              key={r.id}
+              name={r.name}
+              avgHydration={r.avgHydration}
+              tasksDue={r.tasksDue}
+              tags={r.tags}
+              onClick={() => setActiveRoom(r)}
+            />
           ))}
         </div>
       ) : (
@@ -177,6 +179,9 @@ export default function RoomsPage() {
       )}
 
       <footer className="text-xs text-gray-400 mt-6">Last sync: {getLastSync()}</footer>
+      {activeRoom && (
+        <RoomModal room={activeRoom} onClose={() => setActiveRoom(null)} />
+      )}
     </main>
   )
 }

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -1,16 +1,28 @@
+"use client"
+
 type RoomCardProps = {
   name: string
   avgHydration: number
   tasksDue: number
   tags: string[]
+  onClick?: () => void
 }
 
-export default function RoomCard({ name, avgHydration, tasksDue, tags }: RoomCardProps) {
+export default function RoomCard({
+  name,
+  avgHydration,
+  tasksDue,
+  tags,
+  onClick,
+}: RoomCardProps) {
   const pct = Math.max(0, Math.min(100, Math.round(avgHydration)))
   const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
   return (
-    <div className="h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
+    <div
+      className="h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800 cursor-pointer"
+      onClick={onClick}
+    >
       <h3 className="font-semibold text-gray-900 dark:text-gray-100">{name}</h3>
       {tags.length > 0 && (
         <div className="mt-1 flex flex-wrap gap-1">

--- a/components/RoomModal.tsx
+++ b/components/RoomModal.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Modal from './Modal'
+import type { Room } from '@/lib/api'
+
+interface Props {
+  room: Room
+  onClose: () => void
+}
+
+export default function RoomModal({ room, onClose }: Props) {
+  return (
+    <Modal isOpen={true} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-2">{room.name}</h2>
+      {room.tags.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1">
+          {room.tags.map((tag) => (
+            <span
+              key={tag}
+              className="px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+        Avg Hydration: {Math.round(room.avgHydration)}%<br />
+        Tasks Due: {room.tasksDue}
+      </p>
+      <div className="mb-4">
+        <h3 className="font-medium mb-1">Recent Activity</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400">No recent activity.</p>
+      </div>
+      <div className="flex justify-end">
+        <button onClick={onClose} className="px-3 py-1 rounded border">
+          Close
+        </button>
+      </div>
+    </Modal>
+  )
+}


### PR DESCRIPTION
## Summary
- allow RoomCard to trigger actions via onClick
- add RoomModal component to display room details
- show RoomModal in rooms page when a room card is clicked

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b473ed7fc48324801e70c9981965a0