### PR TITLE
Add room status badge

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -186,6 +186,7 @@ export default function RoomsPage() {
               key={r.id}
               id={r.id}
               name={r.name}
+              status={r.status}
               avgHydration={r.avgHydration}
               tasksDue={r.tasksDue}
               tags={r.tags}

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -4,6 +4,7 @@ const sampleRooms = [
   {
     id: 'living-room',
     name: 'Living Room',
+    status: 'healthy',
     avgHydration: 72,
     tasksDue: 2,
     tags: ['indoor', 'bright']
@@ -11,6 +12,7 @@ const sampleRooms = [
   {
     id: 'bedroom',
     name: 'Bedroom',
+    status: 'needs_water',
     avgHydration: 65,
     tasksDue: 1,
     tags: ['indoor', 'low-light']
@@ -18,6 +20,7 @@ const sampleRooms = [
   {
     id: 'office',
     name: 'Office',
+    status: 'warning',
     avgHydration: 82,
     tasksDue: 0,
     tags: ['indoor', 'workspace']

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -3,6 +3,7 @@
 type RoomCardProps = {
   id: string
   name: string
+  status: 'healthy' | 'needs_water' | 'warning'
   avgHydration: number
   tasksDue: number
   tags: string[]
@@ -14,6 +15,7 @@ type RoomCardProps = {
 export default function RoomCard({
   id,
   name,
+  status,
   avgHydration,
   tasksDue,
   tags,
@@ -24,6 +26,12 @@ export default function RoomCard({
   const pct = Math.max(0, Math.min(100, Math.round(avgHydration)))
   const barColor = pct < 30 ? 'bg-red-500' : pct < 60 ? 'bg-yellow-500' : 'bg-flora-leaf'
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
+  const statusColor =
+    status === 'healthy'
+      ? 'bg-green-500 text-white'
+      : status === 'needs_water'
+      ? 'bg-yellow-500 text-gray-800'
+      : 'bg-red-500 text-white'
   return (
     <div
       className="relative h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800 cursor-pointer"
@@ -38,6 +46,11 @@ export default function RoomCard({
         aria-label="Select room"
       />
       <h3 className="font-semibold text-gray-900 dark:text-gray-100">{name}</h3>
+      <span
+        className={`absolute top-2 right-2 px-2 py-0.5 text-xs rounded-full capitalize ${statusColor}`}
+      >
+        {status.replace('_', ' ')}
+      </span>
       {tags.length > 0 && (
         <div className="mt-1 flex flex-wrap gap-1">
           {tags.map((tag) => (

--- a/components/__tests__/RoomCard.test.tsx
+++ b/components/__tests__/RoomCard.test.tsx
@@ -7,6 +7,7 @@ describe('RoomCard', () => {
       <RoomCard
         id="living-room"
         name="Living Room"
+        status="healthy"
         avgHydration={70.2}
         tasksDue={3}
         tags={['indoor', 'bright']}
@@ -21,6 +22,9 @@ describe('RoomCard', () => {
     expect(screen.getByText(/living room/i)).toBeInTheDocument()
     expect(screen.getByText(/Avg Hydration: 70%/i)).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
+    const statusBadge = screen.getByText(/healthy/i)
+    expect(statusBadge).toBeInTheDocument()
+    expect(statusBadge).toHaveClass('bg-green-500')
     expect(screen.getByText('indoor')).toBeInTheDocument()
     expect(screen.getByText('bright')).toBeInTheDocument()
     expect(screen.getByRole('checkbox')).toBeInTheDocument()

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,7 @@
 export type Room = {
   id: string
   name: string
+  status: 'healthy' | 'needs_water' | 'warning'
   avgHydration: number
   tasksDue: number
   tags: string[]


### PR DESCRIPTION
## Summary
- extend Room model with `status` and expose status data in room API
- render color-coded status badge in `RoomCard`
- pass status from rooms page and adjust tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47d5803048324b51716db5abd0dfd