### PR TITLE
Add pagination to room list

### DIFF
--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -27,6 +27,11 @@ const sampleRooms = [
   }
 ]
 
-export async function GET() {
-  return NextResponse.json(sampleRooms)
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const page = parseInt(searchParams.get('page') ?? '1', 10)
+  const limit = parseInt(searchParams.get('limit') ?? '10', 10)
+  const start = (page - 1) * limit
+  const data = sampleRooms.slice(start, start + limit)
+  return NextResponse.json(data)
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -7,8 +7,12 @@ export type Room = {
   tags: string[]
 }
 
-export async function getRooms(): Promise<Room[]> {
-  const res = await fetch('/api/rooms')
+export async function getRooms(page = 1, limit = 10): Promise<Room[]> {
+  const params = new URLSearchParams({
+    page: page.toString(),
+    limit: limit.toString(),
+  })
+  const res = await fetch(`/api/rooms?${params.toString()}`)
   if (!res.ok) {
     throw new Error('Failed to fetch rooms')
   }


### PR DESCRIPTION
## Summary
- add page and limit parameters to `getRooms` API call
- slice rooms in API route based on pagination params
- implement client-side "Load more" pagination on Rooms page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a3d59d188324ba4d232fcf6cce68