### PR TITLE
Add tooltip hints for adding rooms

### DIFF
--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -8,6 +8,7 @@ import RoomSkeleton from "@/components/RoomSkeleton"
 import RoomModal from "@/components/RoomModal"
 import { getLastSync } from "@/lib/utils"
 import { getRooms, deleteRooms, moveRooms, type Room } from "@/lib/api"
+import Tooltip from "@/components/Tooltip"
 
 export default function RoomsPage() {
   type SortBy = "name" | "hydration" | "tasks"
@@ -21,6 +22,7 @@ export default function RoomsPage() {
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [activeRoom, setActiveRoom] = useState<Room | null>(null)
   const [selectedRoomIds, setSelectedRoomIds] = useState<string[]>([])
+  const [showAddRoomTip, setShowAddRoomTip] = useState(false)
 
   useEffect(() => {
     async function loadRooms() {
@@ -35,6 +37,15 @@ export default function RoomsPage() {
       }
     }
     loadRooms()
+  }, [])
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const dismissed = localStorage.getItem("addRoomTipDismissed")
+      if (!dismissed) {
+        setShowAddRoomTip(true)
+      }
+    }
   }, [])
 
   const sortedRooms = [...rooms].sort((a, b) => {
@@ -92,9 +103,27 @@ export default function RoomsPage() {
     <main className="flex-1 p-6">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold">My Rooms</h2>
-        <Link href="/rooms/new" className="text-sm text-blue-500 hover:underline">
-          Add Room
-        </Link>
+        <Tooltip
+          content="Click here to add a room"
+          open={showAddRoomTip}
+          onOpenChange={(open) => {
+            setShowAddRoomTip(open)
+            if (!open) {
+              localStorage.setItem("addRoomTipDismissed", "true")
+            }
+          }}
+        >
+          <Link
+            href="/rooms/new"
+            className="text-sm text-blue-500 hover:underline"
+            onClick={() => {
+              localStorage.setItem("addRoomTipDismissed", "true")
+              setShowAddRoomTip(false)
+            }}
+          >
+            Add Room
+          </Link>
+        </Tooltip>
       </div>
 
       <div className="mb-4 flex flex-wrap items-center gap-2">

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useState, type ReactNode, MouseEvent } from "react"
+
+interface TooltipProps {
+  content: ReactNode
+  children: ReactNode
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export default function Tooltip({ content, children, open, onOpenChange }: TooltipProps) {
+  const [hovered, setHovered] = useState(false)
+  const isOpen = open ?? hovered
+
+  function handleClose(e: MouseEvent) {
+    e.stopPropagation()
+    onOpenChange?.(false)
+  }
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {children}
+      {isOpen && (
+        <div className="absolute left-1/2 -top-8 z-20 -translate-x-1/2 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-xs text-white flex items-center">
+          <span>{content}</span>
+          {onOpenChange && (
+            <button
+              onClick={handleClose}
+              className="ml-2 text-white focus:outline-none"
+              aria-label="Close tooltip"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add reusable Tooltip component
- show first-time hint for adding a room and remember dismissal

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4567bc0832494624a2979dca5bc