### PR TITLE
Add toast notifications for plant events

### DIFF
--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+interface ToastContext {
+  show: (message: string) => void
+}
+
+const ToastContext = createContext<ToastContext | undefined>(undefined)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState<string | null>(null)
+
+  function show(msg: string) {
+    setMessage(msg)
+    setTimeout(() => setMessage(null), 3000)
+  }
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      {message && (
+        <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow">
+          {message}
+        </div>
+      )}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext)
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return ctx.show
+}
+


### PR DESCRIPTION
## Summary
- add simple ToastProvider and useToast hook
- replace alert usage with state updates and toast notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a521a47083248fd3aa289bfa1fbb