### PR TITLE
Add motion animations to cards and dialogs

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { modalOverlayVariants, modalContentVariants, defaultTransition } from '@/lib/motion'
 
 interface ModalProps {
   isOpen: boolean
@@ -42,21 +44,33 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [isOpen, onClose])
 
-  if (!isOpen) return null
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      role="dialog"
-      aria-modal="true"
-    >
-      <div
-        ref={dialogRef}
-        className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg max-w-sm w-full"
-      >
-        {children}
-      </div>
-    </div>
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          role="dialog"
+          aria-modal="true"
+          variants={modalOverlayVariants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          transition={defaultTransition}
+        >
+          <motion.div
+            ref={dialogRef}
+            className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg max-w-sm w-full"
+            variants={modalContentVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={defaultTransition}
+          >
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   )
 }
 

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -1,3 +1,8 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { cardVariants, hover, tap, defaultTransition } from '@/lib/motion'
+
 type PlantCardProps = {
   nickname: string
   species: string
@@ -25,7 +30,16 @@ export default function PlantCard({
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
 
   return (
-    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800">
+    <motion.div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800"
+      variants={cardVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      whileHover={hover}
+      whileTap={tap}
+      transition={defaultTransition}
+    >
       <h3 className="font-semibold text-gray-900 dark:text-gray-100">
         {nickname} <span className="italic text-gray-500 dark:text-gray-400">— {species}</span>
       </h3>
@@ -55,6 +69,7 @@ export default function PlantCard({
           </span>
         </div>
       </div>
-    </div>
+    </motion.div>
   )
 }
+

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { motion } from 'framer-motion'
+import { cardVariants, hover, tap, defaultTransition } from '@/lib/motion'
+
 type RoomCardProps = {
   id: string
   name: string
@@ -33,7 +36,7 @@ export default function RoomCard({
       ? 'bg-yellow-500 text-gray-800'
       : 'bg-red-500 text-white'
   return (
-    <div
+    <motion.div
       tabIndex={0}
       className="relative h-full flex flex-col justify-between rounded-lg border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-800 cursor-pointer focus:outline-none focus:ring-2 focus:ring-flora-leaf focus:ring-offset-2"
       onClick={onClick}
@@ -43,6 +46,13 @@ export default function RoomCard({
           onClick?.()
         }
       }}
+      variants={cardVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      whileHover={hover}
+      whileTap={tap}
+      transition={defaultTransition}
     >
       <input
         type="checkbox"
@@ -94,6 +104,6 @@ export default function RoomCard({
           </span>
         </div>
       </div>
-    </div>
+    </motion.div>
   )
 }

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -1,0 +1,28 @@
+import type { Transition, Variants } from 'framer-motion'
+
+export const defaultTransition: Transition = {
+  duration: 0.2,
+  ease: [0.4, 0, 0.2, 1],
+}
+
+export const cardVariants: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -10 },
+}
+
+export const hover = { scale: 1.02 }
+export const tap = { scale: 0.98 }
+
+export const modalOverlayVariants: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+}
+
+export const modalContentVariants: Variants = {
+  initial: { opacity: 0, y: -20 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: 20 },
+}
+


### PR DESCRIPTION
## Summary
- wrap PlantCard and RoomCard with motion components and shared hover/tap interactions
- animate Modal with fade and slide transitions using AnimatePresence
- centralize motion configs for consistent easing and durations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a750230c8324a2b0ae2f54d4da0b