### PR TITLE
feat: improve dark mode styles

### DIFF
--- a/components/EnvRow.tsx
+++ b/components/EnvRow.tsx
@@ -15,17 +15,17 @@ export default function EnvRow({
   tempUnit = 'F',
 }: EnvRowProps) {
   return (
-    <div className="mt-4 flex gap-6 text-sm items-center">
+    <div className="mt-4 flex gap-6 items-center text-sm text-gray-700 dark:text-gray-300">
       <span className="flex items-center gap-1">
-        <Thermometer className="w-4 h-4 text-red-500" />
+        <Thermometer className="w-4 h-4 text-red-500 dark:text-red-400" />
         {formatTemperature(temperature, tempUnit)}
       </span>
       <span className="flex items-center gap-1">
-        <Droplets className="w-4 h-4 text-blue-500" />
+        <Droplets className="w-4 h-4 text-blue-500 dark:text-blue-400" />
         {formatHumidity(humidity)}
       </span>
       <span className="flex items-center gap-1">
-        <Wind className="w-4 h-4 text-indigo-500" />
+        <Wind className="w-4 h-4 text-indigo-500 dark:text-indigo-400" />
         {formatVpd(vpd)}
       </span>
     </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ type FooterProps = {
 export default function Footer({ lastSync }: FooterProps) {
   const syncTime = lastSync ?? getLastSync()
   return (
-    <footer className="mt-6 text-xs text-gray-500">
+    <footer className="mt-6 text-xs text-gray-500 dark:text-gray-400">
       Last sync: {syncTime}
     </footer>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -33,7 +33,7 @@ export default function Header({ plantsCount, avgHydration, tasksDue }: HeaderPr
         <button
           onClick={toggleTheme}
           aria-label="Toggle theme"
-          className="p-2 rounded-lg border dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition"
         >
           {theme === "dark" ? (
             <Moon className="w-5 h-5 text-gray-200" aria-hidden="true" />

--- a/components/NotebookEntry.tsx
+++ b/components/NotebookEntry.tsx
@@ -8,14 +8,14 @@ type Props = {
 
 export default function NotebookEntry({ icon, note, date }: Props) {
   return (
-    <div className="p-4 border rounded-lg">
-      <p className="text-sm">
+    <div className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800">
+      <p className="text-sm text-gray-700 dark:text-gray-300">
         <span aria-hidden className="mr-1">
           {icon}
         </span>
         {note}
       </p>
-      <p className="text-xs text-gray-500">{date}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">{date}</p>
     </div>
   )
 }

--- a/components/RoomModal.tsx
+++ b/components/RoomModal.tsx
@@ -11,7 +11,7 @@ interface Props {
 export default function RoomModal({ room, onClose }: Props) {
   return (
     <Modal isOpen={true} onClose={onClose}>
-      <h2 className="text-lg font-semibold mb-2">{room.name}</h2>
+      <h2 className="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">{room.name}</h2>
       {room.tags.length > 0 && (
         <div className="mb-2 flex flex-wrap gap-1">
           {room.tags.map((tag) => (
@@ -29,11 +29,14 @@ export default function RoomModal({ room, onClose }: Props) {
         Tasks Due: {room.tasksDue}
       </p>
       <div className="mb-4">
-        <h3 className="font-medium mb-1">Recent Activity</h3>
+        <h3 className="font-medium mb-1 text-gray-900 dark:text-gray-100">Recent Activity</h3>
         <p className="text-sm text-gray-600 dark:text-gray-400">No recent activity.</p>
       </div>
       <div className="flex justify-end">
-        <button onClick={onClose} className="px-3 py-1 rounded border">
+        <button
+          onClick={onClose}
+          className="px-3 py-1 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+        >
           Close
         </button>
       </div>

--- a/components/__tests__/Header.test.tsx
+++ b/components/__tests__/Header.test.tsx
@@ -15,5 +15,7 @@ describe('Header', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(false)
     await userEvent.click(toggle)
     expect(document.documentElement.classList.contains('dark')).toBe(true)
+    await userEvent.click(toggle)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- add dark mode variants to components and borders
- verify theme toggle adds and removes `dark` class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7d9f2448324a3652ab018d95e79