### PR TITLE
feat: enhance dashboard mobile responsiveness

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -4,15 +4,9 @@ import MobileNav from "@/components/MobileNav"
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col md:flex-row min-h-screen">
-      <div className="hidden md:block">
-        <SidebarNav />
-      </div>
-      <div className="flex-1 flex flex-col pb-16 md:pb-0">
-        {children}
-      </div>
-      <div className="md:hidden">
-        <MobileNav />
-      </div>
+      <SidebarNav />
+      <div className="flex-1 flex flex-col pb-16 md:pb-0">{children}</div>
+      <MobileNav />
     </div>
   )
 }

--- a/app/(dashboard)/notebook/page.tsx
+++ b/app/(dashboard)/notebook/page.tsx
@@ -3,8 +3,8 @@ import { Sprout } from "lucide-react"
 
 export default function NotebookPage() {
   return (
-    <main className="flex-1 p-6">
-      <header className="backdrop-blur bg-white/70 sticky top-0 z-10 p-4 flex items-center justify-between">
+    <main className="flex-1 p-4 md:p-6">
+      <header className="backdrop-blur bg-white/70 sticky top-0 z-10 p-4 md:p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
         <h2 className="font-semibold">Lab Notebook</h2>
         <div className="flex gap-2 text-sm">
           <button className="px-2 py-1 border rounded">All</button>
@@ -13,7 +13,7 @@ export default function NotebookPage() {
         </div>
       </header>
 
-      <div className="mt-6 space-y-4">
+      <div className="mt-4 md:mt-6 space-y-4 md:space-y-6">
         <NotebookEntry
           icon={<Sprout className="h-4 w-4" />}
           note="Observation: New leaf unfurled on Delilah (*Monstera deliciosa*)"

--- a/app/(dashboard)/plants/[id]/PlantDetailSkeleton.tsx
+++ b/app/(dashboard)/plants/[id]/PlantDetailSkeleton.tsx
@@ -1,7 +1,7 @@
 export default function PlantDetailSkeleton() {
   return (
-    <div className="space-y-6 animate-pulse">
-      <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+    <div className="space-y-4 md:space-y-6 animate-pulse">
+      <section className="flex flex-col md:flex-row gap-4 md:gap-6 items-center md:items-start">
         <div className="w-full md:w-1/2 rounded-xl border max-h-72 bg-gray-200 dark:bg-gray-700" />
         <div className="space-y-2 md:w-1/2 text-center md:text-left">
           <div className="h-8 w-3/4 mx-auto md:mx-0 rounded bg-gray-200 dark:bg-gray-700" />
@@ -19,7 +19,7 @@ export default function PlantDetailSkeleton() {
         </div>
       </section>
 
-      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
         {[0, 1, 2, 3].map((i) => (
           <div
             key={i}

--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -146,7 +146,7 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
 
   return (
     <main className="flex-1 bg-white dark:bg-gray-900">
-      <div className="p-6 space-y-6">
+      <div className="p-4 md:p-6 space-y-4 md:space-y-6">
         <Link href="/" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
           ← Back to Today
         </Link>
@@ -175,7 +175,7 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
           </div>
         ) : (
           <>
-            <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+            <section className="flex flex-col md:flex-row gap-4 md:gap-6 items-center md:items-start">
               <Image
                 src={plant.photos[0]}
                 alt={plant.nickname}
@@ -238,7 +238,7 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
               </div>
             </section>
 
-            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
               {[
                 { label: "Status", value: plant.status },
                 { label: "Hydration", value: `${plant.hydration}%` },

--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -148,8 +148,8 @@ export default function RoomsPage() {
   }
 
   return (
-    <main className="flex-1 p-6">
-      <div className="mb-4 flex gap-6 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-800">
+    <main className="flex-1 p-4 md:p-6">
+      <div className="mb-4 flex flex-col sm:flex-row gap-4 sm:gap-6 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-800">
         <div className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
           <Home className="h-4 w-4 text-gray-500 dark:text-gray-400" />
           <span>{totalRooms} rooms</span>
@@ -159,7 +159,7 @@ export default function RoomsPage() {
           <span>{roomsNeedingAttention} need attention</span>
         </div>
       </div>
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div className="flex items-center gap-2">
           <h2 className="text-xl font-bold">My Rooms</h2>
           <Tooltip
@@ -274,7 +274,7 @@ export default function RoomsPage() {
       )}
 
       {isLoading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
           {Array.from({ length: 6 }).map((_, i) => (
             <RoomSkeleton key={i} />
           ))}
@@ -289,7 +289,7 @@ export default function RoomsPage() {
           </Link>
         </div>
       ) : view === "grid" ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
           {filteredRooms.map((r) => (
             <RoomCard
               key={r.id}

--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -12,8 +12,8 @@ export default function SciencePanel() {
   const toggleUnit = () => setTempUnit((u) => (u === "F" ? "C" : "F"))
 
   return (
-    <main className="flex-1 p-6">
-      <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 flex items-center justify-between shadow-sm">
+    <main className="flex-1 p-4 md:p-6">
+      <header className="backdrop-blur bg-white/80 sticky top-0 z-10 p-4 md:p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 shadow-sm">
         <h2 className="font-semibold text-xl">Science Panel</h2>
         <button
           onClick={toggleUnit}
@@ -23,7 +23,7 @@ export default function SciencePanel() {
         </button>
       </header>
 
-      <section className="mt-6">
+      <section className="mt-4 md:mt-6">
         <h3 className="font-medium text-gray-800">Environment Data</h3>
         <EnvRow
           temperature={readings.temperature}
@@ -34,7 +34,7 @@ export default function SciencePanel() {
         <TempHumidityChart tempUnit={tempUnit} />
       </section>
 
-      <section className="mt-6">
+      <section className="mt-4 md:mt-6">
         <h3 className="font-medium text-gray-800">VPD Gauge</h3>
         <VPDGauge />
       </section>

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -15,7 +15,7 @@ export default function MobileNav() {
 
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex justify-around py-2 text-xs"
+      className="fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex justify-around py-2 text-xs md:hidden"
       role="navigation"
       aria-label="Mobile navigation"
     >

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -13,7 +13,7 @@ export default function SidebarNav() {
   const pathname = usePathname()
 
   return (
-    <aside className="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
+    <aside className="hidden md:block md:w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
       <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
       <nav
         className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200"


### PR DESCRIPTION
## Summary
- Hide sidebar on small screens and show mobile nav, updating layout accordingly
- Apply mobile-first spacing and breakpoints across dashboard pages
- Improve plant detail skeleton and layout for narrow viewports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7ee9fd48324b511ef086c1e8c20