### PR TITLE
Handle missing plant images gracefully

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -48,7 +48,7 @@ const EVENT_TYPES = {
   },
 } as const
 
-function PlantDetailContent({ params }: { params: { id: string } }) {
+export function PlantDetailContent({ params }: { params: { id: string } }) {
   const [plant, setPlant] = useState<Plant | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -176,15 +176,21 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
         ) : (
           <>
             <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
-              <Image
-                src={plant.photos[0]}
-                alt={plant.nickname}
-                width={800}
-                height={600}
-                sizes="(max-width: 768px) 100vw, 50vw"
-                className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
-                loading="lazy"
-              />
+              {plant.photos && plant.photos.length > 0 ? (
+                <Image
+                  src={plant.photos[0]}
+                  alt={plant.nickname}
+                  width={800}
+                  height={600}
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  className="w-full md:w-1/2 rounded-xl border object-cover max-h-72"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="w-full md:w-1/2 rounded-xl border flex items-center justify-center bg-gray-100 dark:bg-gray-800 max-h-72">
+                  <span className="text-gray-500 dark:text-gray-400">No photo</span>
+                </div>
+              )}
               <div className="space-y-2 md:w-1/2 text-center md:text-left">
                 <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{plant.nickname}</h1>
                 <p className="italic text-gray-500">{plant.species}</p>
@@ -254,7 +260,7 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
 
               <section>
                 <h2 className="text-lg font-semibold mb-3">Timeline</h2>
-                {plant.events.length === 0 ? (
+                {!plant.events || plant.events.length === 0 ? (
                   <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
                 ) : (
                   <ul className="space-y-2">
@@ -289,12 +295,16 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
 
             <section>
               <h2 className="text-lg font-semibold mb-3">Gallery</h2>
-              <Lightbox
-                images={plant.photos.map((src, i) => ({
-                  src,
-                  alt: `${plant.nickname} photo ${i + 1}`,
-                }))}
-              />
+              {plant.photos && plant.photos.length > 0 ? (
+                <Lightbox
+                  images={plant.photos.map((src, i) => ({
+                    src,
+                    alt: `${plant.nickname} photo ${i + 1}`,
+                  }))}
+                />
+              ) : (
+                <p className="text-sm text-gray-500 dark:text-gray-400">No photos available.</p>
+              )}
             </section>
           </>
         )}

--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { PlantDetailContent } from '../[id]/page'
+import { ToastProvider } from '@/components/Toast'
+
+describe('PlantDetailPage', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('shows placeholder when plant has no photos', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        nickname: 'Test',
+        species: 'Species',
+        status: 'Fine',
+        hydration: 50,
+        lastWatered: 'Aug 1',
+        nextDue: 'Aug 5',
+        events: [],
+        // no photos
+      }),
+    }) as any
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '1' }} />
+      </ToastProvider>
+    )
+
+    expect(await screen.findByText(/No photos available/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- avoid calling `.map` on undefined plant photos in detail page
- display placeholders when events or photos are missing
- test plant page with no photo data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a79027dc8324b0115a76b8b3ea5d