### PR TITLE
Add care plan generation via OpenAI

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -28,6 +28,7 @@ interface Plant {
   nextDue: string
   events: PlantEvent[]
   photos: string[]
+  carePlan?: string
 }
 
 const EVENT_TYPES = {
@@ -52,6 +53,8 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
   const [plant, setPlant] = useState<Plant | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [carePlanLoading, setCarePlanLoading] = useState(true)
+  const [carePlanError, setCarePlanError] = useState<string | null>(null)
   const progress = getHydrationProgress(plant?.hydration ?? 0)
   const [waterOpen, setWaterOpen] = useState(false)
   const [fertilizeOpen, setFertilizeOpen] = useState(false)
@@ -140,9 +143,33 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
     }
   }, [params.id])
 
+  const loadCarePlan = useCallback(async () => {
+    setCarePlanLoading(true)
+    setCarePlanError(null)
+    try {
+      const res = await fetch(`/api/plants/${params.id}/care-plan`)
+      if (res.ok) {
+        const data = await res.json()
+        setPlant((prev) => (prev ? { ...prev, carePlan: data.carePlan } : prev))
+      } else {
+        setCarePlanError(`Error ${res.status}`)
+      }
+    } catch (err) {
+      setCarePlanError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setCarePlanLoading(false)
+    }
+  }, [params.id])
+
   useEffect(() => {
     loadPlant()
   }, [loadPlant])
+
+  useEffect(() => {
+    if (plant) {
+      loadCarePlan()
+    }
+  }, [plant, loadCarePlan])
 
   return (
     <main className="flex-1 bg-white dark:bg-gray-900">
@@ -253,6 +280,19 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
                   <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
                 </div>
               ))}
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Care Plan</h2>
+              {carePlanLoading ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">Generating care plan...</p>
+              ) : carePlanError ? (
+                <p className="text-sm text-red-500">{carePlanError}</p>
+              ) : plant.carePlan ? (
+                <p className="text-sm whitespace-pre-line text-gray-700 dark:text-gray-300">{plant.carePlan}</p>
+              ) : (
+                <p className="text-sm text-gray-500 dark:text-gray-400">No care plan available.</p>
+              )}
             </section>
 
               <section>

--- a/app/api/plants/[id]/care-plan/route.ts
+++ b/app/api/plants/[id]/care-plan/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server'
+import { samplePlants } from '@/lib/plants'
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const plant = samplePlants[params.id as keyof typeof samplePlants]
+  if (!plant) {
+    return NextResponse.json({ error: 'Plant not found' }, { status: 404 })
+  }
+
+  if (!plant.carePlan) {
+    const apiKey = process.env.OPENAI_API_KEY
+    const prompt = `Provide a detailed weekly care plan for a ${plant.species} named ${plant.nickname}.`
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'OpenAI API key not configured' },
+        { status: 500 }
+      )
+    }
+
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            { role: 'system', content: 'You are a helpful gardening assistant.' },
+            { role: 'user', content: prompt },
+          ],
+        }),
+      })
+
+      if (!res.ok) {
+        const err = await res.text()
+        return NextResponse.json({ error: err }, { status: res.status })
+      }
+
+      const data = await res.json()
+      plant.carePlan = data.choices?.[0]?.message?.content?.trim() || ''
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'Unknown error' },
+        { status: 500 }
+      )
+    }
+  }
+
+  return NextResponse.json({ carePlan: plant.carePlan })
+}

--- a/app/api/plants/[id]/route.ts
+++ b/app/api/plants/[id]/route.ts
@@ -1,56 +1,5 @@
 import { NextResponse } from 'next/server'
-
-const samplePlants = {
-  "1": {
-    nickname: "Delilah",
-    species: "Monstera deliciosa",
-    status: "Water overdue",
-    hydration: 72,
-    lastWatered: "Aug 25",
-    nextDue: "Aug 30",
-    events: [
-      { id: 1, type: "water", date: "Aug 25" },
-      { id: 2, type: "note", date: "Aug 20", note: "New leaf unfurling" }
-    ],
-    photos: [
-      "https://placehold.co/800x400?text=Delilah",
-      "https://placehold.co/300x300?text=Delilah"
-    ]
-  },
-  "2": {
-    nickname: "Sunny",
-    species: "Sansevieria trifasciata",
-    status: "Fine",
-    hydration: 90,
-    lastWatered: "Aug 27",
-    nextDue: "Sep 5",
-    events: [{ id: 1, type: "water", date: "Aug 27" }],
-    photos: ["https://placehold.co/800x400?text=Sunny"]
-  },
-  "3": {
-    nickname: "Ivy",
-    species: "Epipremnum aureum",
-    status: "Due today",
-    hydration: 70,
-    lastWatered: "Aug 28",
-    nextDue: "Aug 29",
-    events: [{ id: 1, type: "water", date: "Aug 28" }],
-    photos: ["https://placehold.co/800x400?text=Ivy"]
-  },
-  "4": {
-    nickname: "Figgy",
-    species: "Ficus lyrata",
-    status: "Fertilize suggested",
-    hydration: 75,
-    lastWatered: "Aug 23",
-    nextDue: "Sep 2",
-    events: [
-      { id: 1, type: "fertilize", date: "Aug 15" },
-      { id: 2, type: "water", date: "Aug 23" }
-    ],
-    photos: ["https://placehold.co/800x400?text=Figgy"]
-  }
-}
+import { samplePlants } from '@/lib/plants'
 
 export async function GET(
   request: Request,

--- a/lib/plants.ts
+++ b/lib/plants.ts
@@ -1,0 +1,70 @@
+export interface PlantEvent {
+  id: number
+  type: string
+  date: string
+  note?: string
+}
+
+export interface Plant {
+  nickname: string
+  species: string
+  status: string
+  hydration: number
+  lastWatered: string
+  nextDue: string
+  events: PlantEvent[]
+  photos: string[]
+  carePlan?: string
+}
+
+export const samplePlants: Record<string, Plant> = {
+  "1": {
+    nickname: "Delilah",
+    species: "Monstera deliciosa",
+    status: "Water overdue",
+    hydration: 72,
+    lastWatered: "Aug 25",
+    nextDue: "Aug 30",
+    events: [
+      { id: 1, type: "water", date: "Aug 25" },
+      { id: 2, type: "note", date: "Aug 20", note: "New leaf unfurling" }
+    ],
+    photos: [
+      "https://placehold.co/800x400?text=Delilah",
+      "https://placehold.co/300x300?text=Delilah"
+    ]
+  },
+  "2": {
+    nickname: "Sunny",
+    species: "Sansevieria trifasciata",
+    status: "Fine",
+    hydration: 90,
+    lastWatered: "Aug 27",
+    nextDue: "Sep 5",
+    events: [{ id: 1, type: "water", date: "Aug 27" }],
+    photos: ["https://placehold.co/800x400?text=Sunny"]
+  },
+  "3": {
+    nickname: "Ivy",
+    species: "Epipremnum aureum",
+    status: "Due today",
+    hydration: 70,
+    lastWatered: "Aug 28",
+    nextDue: "Aug 29",
+    events: [{ id: 1, type: "water", date: "Aug 28" }],
+    photos: ["https://placehold.co/800x400?text=Ivy"]
+  },
+  "4": {
+    nickname: "Figgy",
+    species: "Ficus lyrata",
+    status: "Fertilize suggested",
+    hydration: 75,
+    lastWatered: "Aug 23",
+    nextDue: "Sep 2",
+    events: [
+      { id: 1, type: "fertilize", date: "Aug 15" },
+      { id: 2, type: "water", date: "Aug 23" }
+    ],
+    photos: ["https://placehold.co/800x400?text=Figgy"]
+  }
+}


### PR DESCRIPTION
## Summary
- centralize sample plant data and include optional care plan field
- add API route to fetch/generate plant care plans using OpenAI and cache them
- display generated care plan on plant detail page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a8efadc083248c1d5e9f6b93ad48