### PR TITLE
Add seasonal care trends chart

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -11,6 +11,7 @@ import WaterModal from "@/components/WaterModal"
 import FertilizeModal from "@/components/FertilizeModal"
 import NoteModal from "@/components/NoteModal"
 import { ToastProvider, useToast } from "@/components/Toast"
+import { CareTrendsChart } from "@/components/Charts"
 
 interface PlantEvent {
   id: number
@@ -253,6 +254,11 @@ function PlantDetailContent({ params }: { params: { id: string } }) {
                   <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
                 </div>
               ))}
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Care Trends</h2>
+              <CareTrendsChart events={plant.events} />
             </section>
 
               <section>

--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
+import { CareTrendsChart } from "@/components/Charts"
 
 const sampleRooms = {
   "living-room": {
@@ -9,6 +10,10 @@ const sampleRooms = {
     plants: [
       { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72 },
       { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70 }
+    ],
+    events: [
+      { type: "water", date: "2024-01-10" },
+      { type: "fertilize", date: "2024-02-12" }
     ]
   },
   "bedroom": {
@@ -17,6 +22,9 @@ const sampleRooms = {
     tasks: 1,
     plants: [
       { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90 }
+    ],
+    events: [
+      { type: "water", date: "2024-03-05" }
     ]
   },
   "office": {
@@ -25,7 +33,8 @@ const sampleRooms = {
     tasks: 0,
     plants: [
       { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75 }
-    ]
+    ],
+    events: []
   }
 }
 
@@ -61,6 +70,11 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
                   </Link>
                 ))}
               </div>
+            </section>
+
+            <section>
+              <h2 className="font-semibold mb-2">Care Trends</h2>
+              <CareTrendsChart events={room.events ?? []} />
             </section>
           </>
         )}

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -2,8 +2,9 @@
 
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
-  RadialBarChart, RadialBar
+  RadialBarChart, RadialBar, BarChart, Bar
 } from "recharts"
+import { aggregateCareByMonth, CareEvent } from "@/lib/seasonal-trends"
 
 // Dummy dataset for environment over 7 days
 const envData = [
@@ -81,6 +82,24 @@ export function VPDGauge() {
           1.2 kPa
         </text>
       </RadialBarChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function CareTrendsChart({ events }: { events: CareEvent[] }) {
+  const data = aggregateCareByMonth(events)
+
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" />
+        <YAxis allowDecimals={false} />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="water" fill="#3b82f6" name="Water" />
+        <Bar dataKey="fertilize" fill="#22c55e" name="Fertilize" />
+      </BarChart>
     </ResponsiveContainer>
   )
 }

--- a/lib/__tests__/seasonal-trends.test.ts
+++ b/lib/__tests__/seasonal-trends.test.ts
@@ -1,0 +1,15 @@
+import { aggregateCareByMonth } from '../seasonal-trends'
+
+describe('aggregateCareByMonth', () => {
+  it('counts water and fertilizer events per month', () => {
+    const events = [
+      { type: 'water', date: '2024-01-15' },
+      { type: 'water', date: '2024-01-20' },
+      { type: 'fertilize', date: '2024-02-10' },
+      { type: 'note', date: '2024-02-11' },
+    ]
+    const result = aggregateCareByMonth(events)
+    expect(result[0]).toEqual({ month: 'Jan', water: 2, fertilize: 0 })
+    expect(result[1]).toEqual({ month: 'Feb', water: 0, fertilize: 1 })
+  })
+})

--- a/lib/seasonal-trends.ts
+++ b/lib/seasonal-trends.ts
@@ -1,0 +1,40 @@
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+]
+
+export interface CareEvent {
+  date: string
+  type: string
+}
+
+export interface MonthlyCareTotals {
+  month: string
+  water: number
+  fertilize: number
+}
+
+export function aggregateCareByMonth(events: CareEvent[]): MonthlyCareTotals[] {
+  const totals = months.map((m) => ({ month: m, water: 0, fertilize: 0 }))
+
+  for (const e of events) {
+    if (e.type !== "water" && e.type !== "fertilize") continue
+    const d = new Date(e.date)
+    if (isNaN(d.getTime())) continue
+    const m = d.getMonth()
+    if (totals[m]) totals[m][e.type as "water" | "fertilize"] += 1
+  }
+
+  return totals
+}
+


### PR DESCRIPTION
## Summary
- aggregate water and fertilize events per month
- show care trends chart for plants and rooms
- add unit test for care aggregation helper

## Testing
- `npm test` *(fails: Cannot find module '/workspace/flora-science/node_modules/next/jest')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4a8fdf3808324a673a640ae289d11