### PR TITLE
feat: add species suggestion API

### DIFF
--- a/app/api/species/route.ts
+++ b/app/api/species/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { getSpeciesSuggestions } from '@/lib/species'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get('q') || ''
+
+  try {
+    const suggestions = await getSpeciesSuggestions(query)
+    return NextResponse.json(suggestions)
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to fetch species suggestions' }, { status: 500 })
+  }
+}

--- a/components/PlantForm.tsx
+++ b/components/PlantForm.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { SpeciesSuggestion } from '@/lib/species'
+
+export default function PlantForm() {
+  const [speciesQuery, setSpeciesQuery] = useState('')
+  const [suggestions, setSuggestions] = useState<SpeciesSuggestion[]>([])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const fetchSuggestions = async () => {
+      if (!speciesQuery) {
+        setSuggestions([])
+        return
+      }
+      try {
+        const res = await fetch(`/api/species?q=${encodeURIComponent(speciesQuery)}`, { signal: controller.signal })
+        if (!res.ok) throw new Error('Failed to fetch species suggestions')
+        const data: SpeciesSuggestion[] = await res.json()
+        setSuggestions(data)
+      } catch (err: any) {
+        if (err.name !== 'AbortError') {
+          console.error(err)
+        }
+      }
+    }
+
+    const timeout = setTimeout(fetchSuggestions, 300)
+    return () => {
+      controller.abort()
+      clearTimeout(timeout)
+    }
+  }, [speciesQuery])
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="species">
+        Species
+      </label>
+      <input
+        id="species"
+        type="text"
+        value={speciesQuery}
+        onChange={(e) => setSpeciesQuery(e.target.value)}
+        className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        placeholder="Start typing to search..."
+      />
+      {suggestions.length > 0 && (
+        <ul className="mt-2 border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 max-h-60 overflow-y-auto">
+          {suggestions.map((s) => (
+            <li key={s.id} className="px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              {s.commonName ?? s.scientificName}{' '}
+              <span className="italic text-xs text-gray-500">{s.scientificName}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/lib/species.ts
+++ b/lib/species.ts
@@ -1,0 +1,39 @@
+export type SpeciesSuggestion = {
+  id: string
+  scientificName: string
+  commonName?: string
+  imageUrl?: string
+}
+
+export async function getSpeciesSuggestions(query: string): Promise<SpeciesSuggestion[]> {
+  const q = query.trim()
+  if (!q) {
+    return []
+  }
+
+  const token = process.env.TREFLE_TOKEN
+  if (!token) {
+    console.warn('TREFLE_TOKEN is not set')
+    return []
+  }
+
+  const params = new URLSearchParams({ token, q })
+  const url = `https://trefle.io/api/v1/species/search?${params.toString()}`
+
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error('Failed to fetch species suggestions')
+  }
+
+  const json = await res.json()
+  if (!json.data) {
+    return []
+  }
+
+  return json.data.map((item: any) => ({
+    id: String(item.id),
+    scientificName: item.scientific_name,
+    commonName: item.common_name,
+    imageUrl: item.image_url,
+  }))
+}


### PR DESCRIPTION
## Summary
- implement `getSpeciesSuggestions` helper to fetch plant data from Trefle
- expose species suggestions via new `/api/species` route
- add `PlantForm` with live species lookup

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a8d995f08324b602d6d982b4cb5d