### PR TITLE
Switch species suggestions to Plant.id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for flora-science
+
+# API key for Plant.id species name suggestions
+PLANT_ID_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 
 # Env
 .env*
+!.env.example
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Flora-Science is a plant care companion built with [Next.js](https://nextjs.org/
    pnpm install
    ```
 
+## 🔑 Environment Variables
+Copy `.env.example` to `.env` and set the following:
+
+```bash
+PLANT_ID_API_KEY=your_api_key_here
+```
+
+This key is used to fetch species name suggestions from Plant.id.
+
 ## 🛠 Development Commands
 | Command | Description |
 | ------- | ----------- |

--- a/lib/__tests__/species.test.ts
+++ b/lib/__tests__/species.test.ts
@@ -1,0 +1,46 @@
+import { getSpeciesSuggestions } from '../species'
+
+describe('getSpeciesSuggestions', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch as any
+    delete process.env.PLANT_ID_API_KEY
+  })
+
+  it('maps Plant.id response to SpeciesSuggestion', async () => {
+    process.env.PLANT_ID_API_KEY = 'test-key'
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 1,
+            name: 'Rosa rubiginosa',
+            common_name: 'sweet briar',
+            image_url: 'https://example.com/rosa.jpg',
+          },
+        ],
+      }),
+    }) as any
+
+    const result = await getSpeciesSuggestions('rosa')
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.plant.id/v3/names?query=rosa',
+      {
+        headers: { 'Api-Key': 'test-key' },
+      }
+    )
+
+    expect(result).toEqual([
+      {
+        id: '1',
+        scientificName: 'Rosa rubiginosa',
+        commonName: 'sweet briar',
+        imageUrl: 'https://example.com/rosa.jpg',
+      },
+    ])
+  })
+})

--- a/lib/species.ts
+++ b/lib/species.ts
@@ -11,16 +11,17 @@ export async function getSpeciesSuggestions(query: string): Promise<SpeciesSugge
     return []
   }
 
-  const token = process.env.TREFLE_TOKEN
-  if (!token) {
-    console.warn('TREFLE_TOKEN is not set')
+  const apiKey = process.env.PLANT_ID_API_KEY
+  if (!apiKey) {
+    console.warn('PLANT_ID_API_KEY is not set')
     return []
   }
 
-  const params = new URLSearchParams({ token, q })
-  const url = `https://trefle.io/api/v1/species/search?${params.toString()}`
+  const url = `https://api.plant.id/v3/names?query=${encodeURIComponent(q)}`
 
-  const res = await fetch(url)
+  const res = await fetch(url, {
+    headers: { 'Api-Key': apiKey },
+  })
   if (!res.ok) {
     throw new Error('Failed to fetch species suggestions')
   }
@@ -32,7 +33,7 @@ export async function getSpeciesSuggestions(query: string): Promise<SpeciesSugge
 
   return json.data.map((item: any) => ({
     id: String(item.id),
-    scientificName: item.scientific_name,
+    scientificName: item.name,
     commonName: item.common_name,
     imageUrl: item.image_url,
   }))

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -13,3 +13,14 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 })
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  writable: true,
+  value: ResizeObserver,
+})


### PR DESCRIPTION
## Summary
- use Plant.id name suggestions with `PLANT_ID_API_KEY`
- document new `PLANT_ID_API_KEY` variable
- add test coverage and stub `ResizeObserver`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4aa939ef48324849b60c2c8863da4