### PR TITLE
Handle null plant events

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -159,6 +159,10 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           // ignore weather errors
         }
         data.nextDue = calculateNextDue(data.lastWatered, w)
+        data.events = (Array.isArray(data.events) ? data.events : []).filter(
+          (e: PlantEvent | null): e is PlantEvent =>
+            e !== null && e !== undefined && typeof e.id !== "undefined"
+        )
         setPlant(data)
       } else {
         setPlant(null)
@@ -343,31 +347,33 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
                   <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
                 ) : (
                   <ul className="space-y-2">
-                    {plant.events.map((e) => {
-                      const type =
-                        EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
-                      const Icon = type.icon
-                      return (
-                        <li
-                          key={e.id}
-                          className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
-                        >
-                          <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
-                          <span className="text-sm flex items-center gap-2">
-                            <span
-                              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ${type.color}`}
-                            >
-                              <span aria-hidden="true">
-                                <Icon className="h-3 w-3" />
+                    {plant.events
+                      .filter((e): e is PlantEvent => e !== null && e !== undefined)
+                      .map((e) => {
+                        const type =
+                          EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
+                        const Icon = type.icon
+                        return (
+                          <li
+                            key={e.id}
+                            className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
+                          >
+                            <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
+                            <span className="text-sm flex items-center gap-2">
+                              <span
+                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ${type.color}`}
+                              >
+                                <span aria-hidden="true">
+                                  <Icon className="h-3 w-3" />
+                                </span>
+                                <span aria-hidden="true">{type.label}</span>
+                                <span className="sr-only">{type.label}</span>
                               </span>
-                              <span aria-hidden="true">{type.label}</span>
-                              <span className="sr-only">{type.label}</span>
+                              {e.type === "note" && e.note}
                             </span>
-                            {e.type === "note" && e.note}
-                          </span>
-                        </li>
-                      )
-                    })}
+                          </li>
+                        )
+                      })}
                   </ul>
                 )}
               </section>

--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -30,4 +30,29 @@ describe('PlantDetailPage', () => {
 
     expect(await screen.findByText(/No photos available/i)).toBeInTheDocument()
   })
+
+  it('handles null events without crashing', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        nickname: 'Test',
+        species: 'Species',
+        status: 'Fine',
+        hydration: 50,
+        lastWatered: 'Aug 1',
+        nextDue: 'Aug 5',
+        events: [null, { id: 1, type: 'water', date: 'Aug 1' }],
+        photos: [],
+      }),
+    }) as any
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '1' }} />
+      </ToastProvider>
+    )
+
+    expect(await screen.findByText(/Timeline/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/Watered/i).length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Summary
- guard against malformed plant events when loading plant data
- skip null events when rendering the timeline
- add regression test for null events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4aaf851b88324b2341c71648f4732