### PR TITLE
feat: add plants list API route

### DIFF
--- a/app/api/plants/route.ts
+++ b/app/api/plants/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { samplePlants } from '@/lib/plants'
+
+export async function GET() {
+  return NextResponse.json(
+    Object.entries(samplePlants).map(([id, plant]) => ({ id, ...plant }))
+  )
+}


### PR DESCRIPTION
## Summary
- add `app/api/plants` route that exposes sample plant data

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4ae074a448324a66c410506348a5a