### PR TITLE
feat: whitelist placeholder image host

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [{ protocol: 'https', hostname: 'placehold.co' }],
+    // or: domains: ['placehold.co']
+  },
+};
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow `placehold.co` placeholder host for remote images

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68b4affcaaf0832484e3b948f961e15d