### PR TITLE
docs: document OpenAI API key and stub care plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 
 # API key for Plant.id species name suggestions
 PLANT_ID_API_KEY=
+
+# API key for OpenAI care plan generation
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Copy `.env.example` to `.env` and set the following:
 
 ```bash
 PLANT_ID_API_KEY=your_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
 ```
 
-This key is used to fetch species name suggestions from Plant.id.
+`PLANT_ID_API_KEY` fetches species name suggestions from Plant.id.
+`OPENAI_API_KEY` enables AI-generated care plans. Create one at https://platform.openai.com/account/api-keys.
 
 ## 🛠 Development Commands
 | Command | Description |

--- a/app/api/plants/[id]/care-plan/route.ts
+++ b/app/api/plants/[id]/care-plan/route.ts
@@ -15,10 +15,10 @@ export async function GET(
     const prompt = `Provide a detailed weekly care plan for a ${plant.species} named ${plant.nickname}.`
 
     if (!apiKey) {
-      return NextResponse.json(
-        { error: 'OpenAI API key not configured' },
-        { status: 500 }
-      )
+      plant.carePlan =
+        plant.carePlan ||
+        'Set OPENAI_API_KEY to enable AI-generated care plans.'
+      return NextResponse.json({ carePlan: plant.carePlan })
     }
 
     try {


### PR DESCRIPTION
## Summary
- document OPENAI_API_KEY usage in README and .env.example
- return stubbed care-plan message when OPENAI_API_KEY is missing

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dev` & `curl http://localhost:3000/api/plants/1/care-plan`
- `OPENAI_API_KEY=fake pnpm dev` & `curl http://localhost:3000/api/plants/1/care-plan`

------
https://chatgpt.com/codex/tasks/task_e_68b4b0602f7c8324b407629da565fa89