### PR TITLE
fix: let next page mount without delay

### DIFF
--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation"
 export default function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   return (
-    <AnimatePresence mode="wait">
+    <AnimatePresence mode="sync" initial={false}>
       <motion.div
         key={pathname}
         initial={{ opacity: 0, y: 10 }}


### PR DESCRIPTION
## Summary
- change page transition to mount new route immediately by setting `initial={false}` and `mode="sync"`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6da67248324b3f0a87f89e931bb