### PR TITLE
fix: show pages immediately

### DIFF
--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -1,21 +1,18 @@
 "use client"
 
-import { motion, AnimatePresence } from "framer-motion"
+import { motion } from "framer-motion"
 import { usePathname } from "next/navigation"
 
 export default function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   return (
-    <AnimatePresence mode="wait">
-      <motion.div
-        key={pathname}
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -10 }}
-        transition={{ duration: 0.3 }}
-      >
-        {children}
-      </motion.div>
-    </AnimatePresence>
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      {children}
+    </motion.div>
   )
 }


### PR DESCRIPTION
## Summary
- remove AnimatePresence wrapper to avoid exit animation blocking new pages

## Testing
- `pnpm test`
- `pnpm lint` (React hook dependency warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b4b6da67248324b3f0a87f89e931bb