### PR TITLE
Replace sidebar title with sprout icon

### DIFF
--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -1,6 +1,7 @@
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { Sprout } from "lucide-react"
 
 const navItems = [
   { href: "/", label: "Today" },
@@ -14,7 +15,7 @@ export default function SidebarNav() {
 
   return (
     <aside className="hidden md:block md:w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
-      <h2 className="font-bold text-lg mb-6 text-flora-leaf">Flora-Science</h2>
+      <Sprout className="w-6 h-6 mb-6 text-flora-leaf" aria-hidden="true" />
       <nav
         className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200"
         role="navigation"


### PR DESCRIPTION
## Summary
- remove hardcoded "Flora-Science" header in sidebar
- display a small sprout icon as the sidebar logo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4cd6bc0088324bec00e78c451f7d4