### PR TITLE
feat: add icons and styling to sidebar nav

### DIFF
--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -1,36 +1,43 @@
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Sprout } from "lucide-react"
+import {
+  Sprout,
+  Calendar,
+  Home,
+  FlaskConical,
+  Notebook,
+} from "lucide-react"
 
 const navItems = [
-  { href: "/", label: "Today" },
-  { href: "/rooms", label: "Rooms" },
-  { href: "/science", label: "Science Panel" },
-  { href: "/notebook", label: "Lab Notebook" },
+  { href: "/", label: "Today", icon: Calendar },
+  { href: "/rooms", label: "Rooms", icon: Home },
+  { href: "/science", label: "Science Panel", icon: FlaskConical },
+  { href: "/notebook", label: "Lab Notebook", icon: Notebook },
 ]
 
 export default function SidebarNav() {
   const pathname = usePathname()
 
   return (
-    <aside className="hidden md:block md:w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-6">
+    <aside className="hidden md:block md:w-64 bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 p-6">
       <Sprout className="w-6 h-6 mb-6 text-flora-leaf" aria-hidden="true" />
       <nav
         className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200"
         role="navigation"
         aria-label="Sidebar navigation"
       >
-        {navItems.map(({ href, label }) => {
+        {navItems.map(({ href, label, icon: Icon }) => {
           const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
           return (
             <Link
               key={href}
               href={href}
-              className={`block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${active ? "bg-gray-100 dark:bg-gray-800 text-flora-leaf" : ""}`}
+              className={`flex items-center px-2 py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
               aria-current={active ? "page" : undefined}
               aria-label={label}
             >
+              <Icon className="h-5 w-5 mr-2" />
               {label}
             </Link>
           )


### PR DESCRIPTION
## Summary
- add icon imports for Calendar, Home, FlaskConical, and Notebook
- render nav items with icons and gradient hover styles
- refine sidebar aesthetics with subtle gradients and transitions

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module 'next/jest')*


------
https://chatgpt.com/codex/tasks/task_e_68b4d21ed35c8324b4709f258b4e9b42