### PR TITLE
Add ET₀ weather inputs and water balance chart

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -1,13 +1,77 @@
 "use client"
 
 import { useState } from "react"
-import { TempHumidityChart, VPDGauge } from "@/components/Charts"
+import {
+  TempHumidityChart,
+  VPDGauge,
+  WaterBalanceChart,
+} from "@/components/Charts"
+import { waterBalanceSeries, WeatherDay, WaterEvent } from "@/lib/plant-metrics"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
 
 export default function SciencePanel() {
   const readings = { temperature: 75, humidity: 52, vpd: 1.2 }
   const [tempUnit, setTempUnit] = useState<"F" | "C">("F")
+
+  const weather: WeatherDay[] = [
+    {
+      date: "2024-08-21",
+      temperature: 24,
+      humidity: 55,
+      solarRadiation: 18,
+      windSpeed: 2,
+    },
+    {
+      date: "2024-08-22",
+      temperature: 25,
+      humidity: 50,
+      solarRadiation: 20,
+      windSpeed: 1.8,
+    },
+    {
+      date: "2024-08-23",
+      temperature: 26,
+      humidity: 48,
+      solarRadiation: 19,
+      windSpeed: 2.1,
+    },
+    {
+      date: "2024-08-24",
+      temperature: 27,
+      humidity: 45,
+      solarRadiation: 21,
+      windSpeed: 2.4,
+    },
+    {
+      date: "2024-08-25",
+      temperature: 25,
+      humidity: 50,
+      solarRadiation: 17,
+      windSpeed: 1.9,
+    },
+    {
+      date: "2024-08-26",
+      temperature: 24,
+      humidity: 52,
+      solarRadiation: 16,
+      windSpeed: 1.5,
+    },
+    {
+      date: "2024-08-27",
+      temperature: 23,
+      humidity: 55,
+      solarRadiation: 15,
+      windSpeed: 1.7,
+    },
+  ]
+
+  const events: WaterEvent[] = [
+    { date: "2024-08-22", amount: 5 },
+    { date: "2024-08-25", amount: 5 },
+  ]
+
+  const waterData = waterBalanceSeries(weather, events)
 
   const toggleUnit = () => setTempUnit((u) => (u === "F" ? "C" : "F"))
 
@@ -37,6 +101,11 @@ export default function SciencePanel() {
       <section className="mt-4 md:mt-6">
         <h3 className="font-medium text-gray-800">VPD Gauge</h3>
         <VPDGauge />
+      </section>
+
+      <section className="mt-4 md:mt-6">
+        <h3 className="font-medium text-gray-800">Water Balance</h3>
+        <WaterBalanceChart data={waterData} />
       </section>
 
       <Footer />

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -1,8 +1,19 @@
 "use client"
 
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
-  RadialBarChart, RadialBar, BarChart, Bar
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  RadialBarChart,
+  RadialBar,
+  BarChart,
+  Bar,
+  ComposedChart,
 } from "recharts"
 import { aggregateCareByMonth, CareEvent } from "@/lib/seasonal-trends"
 
@@ -100,6 +111,33 @@ export function CareTrendsChart({ events }: { events: CareEvent[] }) {
         <Bar dataKey="water" fill="#3b82f6" name="Water" />
         <Bar dataKey="fertilize" fill="#22c55e" name="Fertilize" />
       </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+export interface WaterBalanceDatum {
+  date: string
+  et0: number
+  water: number
+}
+
+export function WaterBalanceChart({ data }: { data: WaterBalanceDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <ComposedChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="water" fill="#3b82f6" name="Water (mm)" />
+        <Line
+          type="monotone"
+          dataKey="et0"
+          stroke="#f59e0b"
+          name="ET₀ (mm)"
+        />
+      </ComposedChart>
     </ResponsiveContainer>
   )
 }

--- a/lib/__tests__/plant-metrics.test.ts
+++ b/lib/__tests__/plant-metrics.test.ts
@@ -1,0 +1,14 @@
+import { calculateEt0, waterBalanceSeries, WeatherDay, WaterEvent } from '../plant-metrics'
+
+describe('plant metrics', () => {
+  it('calculates et0 and water balance', () => {
+    const weather: WeatherDay[] = [
+      { date: '2024-08-21', temperature: 25, humidity: 50, solarRadiation: 20, windSpeed: 2 },
+    ]
+    const events: WaterEvent[] = [{ date: '2024-08-21', amount: 5 }]
+    const et0 = calculateEt0(weather[0])
+    expect(typeof et0).toBe('number')
+    const series = waterBalanceSeries(weather, events)
+    expect(series).toEqual([{ date: '2024-08-21', et0, water: 5 }])
+  })
+})

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -1,0 +1,59 @@
+export interface WeatherDay {
+  date: string
+  temperature: number // °C
+  humidity: number // %
+  solarRadiation: number // MJ/m²
+  windSpeed: number // m/s
+}
+
+export interface WaterEvent {
+  date: string // ISO string YYYY-MM-DD
+  amount: number // mm of water applied
+}
+
+// Calculate daily reference evapotranspiration (ET₀) using a simplified
+// FAO-56 Penman-Monteith equation. Assumes near sea level pressure.
+export function calculateEt0(day: WeatherDay): number {
+  const t = day.temperature
+  const rh = day.humidity
+  const rs = day.solarRadiation
+  const u2 = day.windSpeed
+
+  // Saturation vapor pressure (kPa)
+  const es = 0.6108 * Math.exp((17.27 * t) / (t + 237.3))
+  // Actual vapor pressure (kPa)
+  const ea = es * (rh / 100)
+  // Slope vapor pressure curve (kPa/°C)
+  const delta = (4098 * es) / Math.pow(t + 237.3, 2)
+  // Psychrometric constant (kPa/°C) at sea level
+  const gamma = 0.665e-3 * 101.3
+  // Approximate net radiation assuming albedo 0.23
+  const rn = 0.77 * rs
+
+  const et0 =
+    (0.408 * delta * rn +
+      gamma * (900 / (t + 273)) * u2 * (es - ea)) /
+    (delta + gamma * (1 + 0.34 * u2))
+
+  return Number(et0.toFixed(2))
+}
+
+export interface WaterBalanceDatum {
+  date: string
+  et0: number
+  water: number
+}
+
+// Combine weather data and watering events into a time series of water balance.
+export function waterBalanceSeries(
+  weather: WeatherDay[],
+  events: WaterEvent[],
+): WaterBalanceDatum[] {
+  return weather.map((w) => {
+    const et0 = calculateEt0(w)
+    const water = events
+      .filter((e) => e.date === w.date)
+      .reduce((sum, e) => sum + e.amount, 0)
+    return { date: w.date, et0, water }
+  })
+}

--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -1,6 +1,8 @@
 export interface Weather {
   temperature: number
   humidity: number
+  solarRadiation: number
+  windSpeed: number
 }
 
 export async function fetchDailyWeather(lat: number, lon: number): Promise<Weather> {
@@ -8,16 +10,27 @@ export async function fetchDailyWeather(lat: number, lon: number): Promise<Weath
     latitude: lat.toString(),
     longitude: lon.toString(),
     current: 'temperature_2m,relative_humidity_2m',
+    daily: 'temperature_2m_max,temperature_2m_min,relative_humidity_2m_mean,shortwave_radiation_sum,wind_speed_10m_max',
     timezone: 'auto',
+    past_days: '1',
   })
   const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`)
   if (!res.ok) {
     throw new Error('Failed to fetch weather')
   }
   const data = await res.json()
+  const tMax = data.daily.temperature_2m_max?.[0]
+  const tMin = data.daily.temperature_2m_min?.[0]
+  const temperature =
+    typeof tMax === 'number' && typeof tMin === 'number'
+      ? (tMax + tMin) / 2
+      : data.current.temperature_2m
   return {
-    temperature: data.current.temperature_2m,
-    humidity: data.current.relative_humidity_2m,
+    temperature,
+    humidity:
+      data.daily.relative_humidity_2m_mean?.[0] ?? data.current.relative_humidity_2m,
+    solarRadiation: data.daily.shortwave_radiation_sum?.[0] ?? 0,
+    windSpeed: data.daily.wind_speed_10m_max?.[0] ?? 0,
   }
 }
 


### PR DESCRIPTION
## Summary
- fetch solar radiation and wind fields from Open-Meteo for ET₀ calculations
- add plant-metrics utilities to compute ET₀ and daily water balance
- visualize ET₀ vs. watering with new WaterBalanceChart on the science dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d342fa508324acefc3c95c853339