### PR TITLE
Fix charts rendering error

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -140,6 +140,9 @@ export function WaterBalanceChart({ data }: { data: WaterBalanceDatum[] }) {
           name="ET₀ (mm)"
         />
       </ComposedChart>
+    </ResponsiveContainer>
+  )
+}
 
 export function NutrientLevelChart({
   lastFertilized,

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -56,6 +56,7 @@ export function waterBalanceSeries(
       .reduce((sum, e) => sum + e.amount, 0)
     return { date: w.date, et0, water }
   })
+}
 
 export const MS_PER_DAY = 1000 * 60 * 60 * 24
 


### PR DESCRIPTION
## Summary
- close WaterBalanceChart JSX to prevent syntax error
- close waterBalanceSeries function for linting

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d593ab408324bd96d7f6da9c529f