### PR TITLE
Add plant stress index calculations and charts

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -11,8 +11,8 @@ import WaterModal from "@/components/WaterModal"
 import FertilizeModal from "@/components/FertilizeModal"
 import NoteModal from "@/components/NoteModal"
 import { ToastProvider, useToast } from "@/components/Toast"
-import { CareTrendsChart, NutrientLevelChart } from "@/components/Charts"
-import { calculateNutrientAvailability } from "@/lib/plant-metrics"
+import { CareTrendsChart, NutrientLevelChart, StressIndexGauge } from "@/components/Charts"
+import { calculateNutrientAvailability, calculateStressIndex } from "@/lib/plant-metrics"
 
 import { getWeatherForUser, type Weather } from "@/lib/weather"
 import { samplePlants } from "@/lib/plants"
@@ -395,6 +395,18 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
                   <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
                 </div>
               ))}
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Stress Level</h2>
+              <StressIndexGauge
+                value={calculateStressIndex({
+                  overdueDays: plant.status === "Water overdue" ? 1 : 0,
+                  hydration: plant.hydration,
+                  temperature: weather?.temperature ?? 25,
+                  light: 50,
+                })}
+              />
             </section>
 
             <section>

--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -5,8 +5,10 @@ import {
   TempHumidityChart,
   VPDGauge,
   WaterBalanceChart,
+  StressIndexGauge,
+  StressIndexChart,
 } from "@/components/Charts"
-import { waterBalanceSeries, WeatherDay, WaterEvent } from "@/lib/plant-metrics"
+import { waterBalanceSeries, WeatherDay, WaterEvent, stressTrend } from "@/lib/plant-metrics"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
 
@@ -73,6 +75,19 @@ export default function SciencePanel() {
 
   const waterData = waterBalanceSeries(weather, events)
 
+  // Dummy stress readings for the last 7 days
+  const stressReadings = [
+    { date: "2024-08-21", overdueDays: 0, hydration: 80, temperature: 24, light: 55 },
+    { date: "2024-08-22", overdueDays: 0, hydration: 78, temperature: 25, light: 60 },
+    { date: "2024-08-23", overdueDays: 1, hydration: 70, temperature: 26, light: 50 },
+    { date: "2024-08-24", overdueDays: 2, hydration: 65, temperature: 27, light: 45 },
+    { date: "2024-08-25", overdueDays: 1, hydration: 68, temperature: 25, light: 48 },
+    { date: "2024-08-26", overdueDays: 0, hydration: 75, temperature: 24, light: 52 },
+    { date: "2024-08-27", overdueDays: 0, hydration: 77, temperature: 23, light: 55 },
+  ]
+  const stressData = stressTrend(stressReadings)
+  const currentStress = stressData[stressData.length - 1]?.stress ?? 0
+
   const toggleUnit = () => setTempUnit((u) => (u === "F" ? "C" : "F"))
 
   return (
@@ -106,6 +121,14 @@ export default function SciencePanel() {
       <section className="mt-4 md:mt-6">
         <h3 className="font-medium text-gray-800">Water Balance</h3>
         <WaterBalanceChart data={waterData} />
+      </section>
+
+      <section className="mt-4 md:mt-6">
+        <h3 className="font-medium text-gray-800">Plant Stress</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <StressIndexGauge value={currentStress} />
+          <StressIndexChart data={stressData} />
+        </div>
       </section>
 
       <Footer />

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -17,7 +17,12 @@ import {
 
 } from "recharts"
 import { aggregateCareByMonth, CareEvent } from "@/lib/seasonal-trends"
-import { calculateNutrientAvailability } from "@/lib/plant-metrics"
+import {
+  calculateNutrientAvailability,
+  calculateStressIndex,
+  stressTrend,
+  type StressDatum,
+} from "@/lib/plant-metrics"
 
 // Dummy dataset for environment over 7 days
 const envData = [
@@ -140,6 +145,55 @@ export function WaterBalanceChart({ data }: { data: WaterBalanceDatum[] }) {
           name="ET₀ (mm)"
         />
       </ComposedChart>
+    </ResponsiveContainer>
+  )
+}
+
+// Display a plant stress index as a radial gauge (0-100)
+export function StressIndexGauge({ value }: { value: number }) {
+  const data = [{ name: "Stress", value, fill: "#ef4444" }]
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <RadialBarChart
+        cx="50%"
+        cy="50%"
+        innerRadius="80%"
+        outerRadius="100%"
+        barSize={20}
+        data={data}
+        startAngle={180}
+        endAngle={0}
+      >
+        <RadialBar minAngle={15} background clockWise dataKey="value" />
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          className="text-lg fill-gray-700"
+        >
+          {value}
+        </text>
+      </RadialBarChart>
+    </ResponsiveContainer>
+  )
+}
+
+// Line chart for stress index trends
+export function StressIndexChart({ data }: { data: StressDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis domain={[0, 100]} />
+        <Tooltip />
+        <Legend />
+        <Line type="monotone" dataKey="stress" stroke="#ef4444" name="Stress" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
 
 export function NutrientLevelChart({
   lastFertilized,

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -57,6 +57,7 @@ export function waterBalanceSeries(
     return { date: w.date, et0, water }
   })
 
+}
 export const MS_PER_DAY = 1000 * 60 * 60 * 24
 
 export function calculateNutrientAvailability(
@@ -70,4 +71,57 @@ export function calculateNutrientAvailability(
   const decayed = Math.max(0, Math.min(100, nutrientLevel - diffDays * 2))
   return decayed
 
+}
+
+export interface StressInput {
+  /** Number of days a task is overdue. Negative values are treated as 0. */
+  overdueDays: number
+  /** Current hydration level as a percent 0-100 */
+  hydration: number
+  /** Ambient temperature in °C */
+  temperature: number
+  /** Daily light reading (arbitrary units, 0-100 recommended) */
+  light: number
+}
+
+export interface StressDatum {
+  date: string
+  stress: number
+}
+
+// Calculate a simple stress index on a 0-100 scale. Higher values indicate
+// greater plant stress. The formula is intentionally lightweight – it simply
+// normalises each factor to a 0-100 range and then combines them with weights.
+export function calculateStressIndex({
+  overdueDays,
+  hydration,
+  temperature,
+  light,
+}: StressInput): number {
+  // Overdue watering contributes up to 30 points. Each overdue day adds 10.
+  const overdueScore = Math.min(30, Math.max(0, overdueDays) * 10)
+
+  // Hydration is inverted: 100% hydration => 0 stress, 0% => 40 stress.
+  const hydrationScore = Math.min(40, Math.max(0, 40 * (1 - hydration / 100)))
+
+  // Temperature – assume an optimal temperature of 25°C. Each degree away adds
+  // 1.5 points up to a max of 15.
+  const tempScore = Math.min(15, Math.abs(temperature - 25) * 1.5)
+
+  // Light – assume an ideal reading of 50 (on a 0–100 scale). Each unit away
+  // adds 0.3 points up to 15.
+  const lightScore = Math.min(15, Math.abs(light - 50) * 0.3)
+
+  const total = overdueScore + hydrationScore + tempScore + lightScore
+  return Math.round(Math.max(0, Math.min(100, total)))
+}
+
+// Generate a series of stress index values for trend visualisation.
+export function stressTrend(
+  readings: (StressInput & { date: string })[],
+): StressDatum[] {
+  return readings.map((r) => ({
+    date: r.date,
+    stress: calculateStressIndex(r),
+  }))
 }


### PR DESCRIPTION
## Summary
- compute stress index and daily trend utilities
- add StressIndexGauge and StressIndexChart components
- surface stress metrics on science dashboard and plant details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d5ef5f7883248a16254c5fd485a2