### PR TITLE
Add task completion chart and aggregator

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -7,8 +7,15 @@ import {
   WaterBalanceChart,
   StressIndexGauge,
   StressIndexChart,
+  TaskCompletionChart,
 } from "@/components/Charts"
-import { waterBalanceSeries, WeatherDay, WaterEvent, stressTrend } from "@/lib/plant-metrics"
+import {
+  waterBalanceSeries,
+  WeatherDay,
+  WaterEvent,
+  stressTrend,
+} from "@/lib/plant-metrics"
+import { CareEvent } from "@/lib/seasonal-trends"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
 
@@ -88,6 +95,15 @@ export default function SciencePanel() {
   const stressData = stressTrend(stressReadings)
   const currentStress = stressData[stressData.length - 1]?.stress ?? 0
 
+  const taskEvents: CareEvent[] = [
+    { date: "2024-01-05", type: "completed" },
+    { date: "2024-01-12", type: "missed" },
+    { date: "2024-02-03", type: "completed" },
+    { date: "2024-02-20", type: "completed" },
+    { date: "2024-03-15", type: "missed" },
+    { date: "2024-03-22", type: "completed" },
+  ]
+
   const toggleUnit = () => setTempUnit((u) => (u === "F" ? "C" : "F"))
 
   return (
@@ -129,6 +145,11 @@ export default function SciencePanel() {
           <StressIndexGauge value={currentStress} />
           <StressIndexChart data={stressData} />
         </div>
+      </section>
+
+      <section className="mt-4 md:mt-6">
+        <h3 className="font-medium text-gray-800">Task Completion</h3>
+        <TaskCompletionChart events={taskEvents} />
       </section>
 
       <Footer />

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -16,13 +16,12 @@ import {
   ComposedChart,
 
 } from "recharts"
-import { aggregateCareByMonth, CareEvent } from "@/lib/seasonal-trends"
 import {
-  calculateNutrientAvailability,
-  calculateStressIndex,
-  stressTrend,
-  type StressDatum,
-} from "@/lib/plant-metrics"
+  aggregateCareByMonth,
+  aggregateTaskCompletion,
+  CareEvent,
+} from "@/lib/seasonal-trends"
+import { calculateNutrientAvailability, type StressDatum } from "@/lib/plant-metrics"
 
 // Dummy dataset for environment over 7 days
 const envData = [
@@ -118,6 +117,41 @@ export function CareTrendsChart({ events }: { events: CareEvent[] }) {
         <Bar dataKey="water" fill="#3b82f6" name="Water" />
         <Bar dataKey="fertilize" fill="#22c55e" name="Fertilize" />
       </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function TaskCompletionChart({ events }: { events: CareEvent[] }) {
+  const data = aggregateTaskCompletion(events).map((t) => {
+    const total = t.completed + t.missed
+    return {
+      month: t.month,
+      completed: total ? (t.completed / total) * 100 : 0,
+      missed: total ? (t.missed / total) * 100 : 0,
+    }
+  })
+
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" />
+        <YAxis domain={[0, 100]} />
+        <Tooltip />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="completed"
+          stroke="#22c55e"
+          name="Completed (%)"
+        />
+        <Line
+          type="monotone"
+          dataKey="missed"
+          stroke="#ef4444"
+          name="Missed (%)"
+        />
+      </LineChart>
     </ResponsiveContainer>
   )
 }

--- a/lib/__tests__/seasonal-trends.test.ts
+++ b/lib/__tests__/seasonal-trends.test.ts
@@ -1,4 +1,7 @@
-import { aggregateCareByMonth } from '../seasonal-trends'
+import {
+  aggregateCareByMonth,
+  aggregateTaskCompletion,
+} from '../seasonal-trends'
 
 describe('aggregateCareByMonth', () => {
   it('counts water and fertilizer events per month', () => {
@@ -11,5 +14,19 @@ describe('aggregateCareByMonth', () => {
     const result = aggregateCareByMonth(events)
     expect(result[0]).toEqual({ month: 'Jan', water: 2, fertilize: 0 })
     expect(result[1]).toEqual({ month: 'Feb', water: 0, fertilize: 1 })
+  })
+})
+
+describe('aggregateTaskCompletion', () => {
+  it('counts completed and missed tasks per month', () => {
+    const events = [
+      { type: 'completed', date: '2024-01-15' },
+      { type: 'missed', date: '2024-01-20' },
+      { type: 'completed', date: '2024-02-10' },
+      { type: 'note', date: '2024-02-11' },
+    ]
+    const result = aggregateTaskCompletion(events)
+    expect(result[0]).toEqual({ month: 'Jan', completed: 1, missed: 1 })
+    expect(result[1]).toEqual({ month: 'Feb', completed: 1, missed: 0 })
   })
 })

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -58,7 +58,6 @@ export function waterBalanceSeries(
   })
 }
 
-}
 export const MS_PER_DAY = 1000 * 60 * 60 * 24
 
 export function calculateNutrientAvailability(

--- a/lib/seasonal-trends.ts
+++ b/lib/seasonal-trends.ts
@@ -24,6 +24,12 @@ export interface MonthlyCareTotals {
   fertilize: number
 }
 
+export interface TaskCompletionTotals {
+  month: string
+  completed: number
+  missed: number
+}
+
 export function aggregateCareByMonth(events: CareEvent[]): MonthlyCareTotals[] {
   const totals = months.map((m) => ({ month: m, water: 0, fertilize: 0 }))
 
@@ -33,6 +39,22 @@ export function aggregateCareByMonth(events: CareEvent[]): MonthlyCareTotals[] {
     if (isNaN(d.getTime())) continue
     const m = d.getMonth()
     if (totals[m]) totals[m][e.type as "water" | "fertilize"] += 1
+  }
+
+  return totals
+}
+
+export function aggregateTaskCompletion(
+  events: CareEvent[]
+): TaskCompletionTotals[] {
+  const totals = months.map((m) => ({ month: m, completed: 0, missed: 0 }))
+
+  for (const e of events) {
+    if (e.type !== "completed" && e.type !== "missed") continue
+    const d = new Date(e.date)
+    if (isNaN(d.getTime())) continue
+    const m = d.getMonth()
+    if (totals[m]) totals[m][e.type as "completed" | "missed"] += 1
   }
 
   return totals


### PR DESCRIPTION
## Summary
- aggregate completed and missed tasks per month in `aggregateTaskCompletion`
- visualize completion trends with new `TaskCompletionChart` and render in Science panel
- cover new aggregation with tests and fix stray brace in `plant-metrics`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d6ecf1e083248be5b9a089f98091