### PR TITLE
Remove unused sidebar icon

### DIFF
--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -1,7 +1,6 @@
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Sprout } from "lucide-react"
 import { motion } from "framer-motion"
 
 import { navItems } from "./navItems"
@@ -11,7 +10,6 @@ export default function SidebarNav() {
 
   return (
     <aside className="hidden md:block md:w-64 bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 p-6">
-      <Sprout className="w-6 h-6 mb-6 text-flora-leaf" aria-hidden="true" />
       <nav
         className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200"
         role="navigation"

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -57,8 +57,6 @@ export function waterBalanceSeries(
     return { date: w.date, et0, water }
   })
 }
-
-}
 export const MS_PER_DAY = 1000 * 60 * 60 * 24
 
 export function calculateNutrientAvailability(


### PR DESCRIPTION
## Summary
- remove decorative sprout icon from sidebar nav on desktop
- fix stray closing brace in plant-metrics to restore build

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c206aef88324a720b31ae276949c