### PR TITLE
feat: add plant timeline heatmap

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import Image from "next/image"
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useMemo } from "react"
 import Lightbox from "@/components/Lightbox"
 import { Droplet, Sprout, FileText } from "lucide-react"
 import { getHydrationProgress } from "@/components/PlantCard"
@@ -11,8 +11,14 @@ import WaterModal from "@/components/WaterModal"
 import FertilizeModal from "@/components/FertilizeModal"
 import NoteModal from "@/components/NoteModal"
 import { ToastProvider, useToast } from "@/components/Toast"
-import { CareTrendsChart, NutrientLevelChart, StressIndexGauge } from "@/components/Charts"
+import {
+  CareTrendsChart,
+  NutrientLevelChart,
+  StressIndexGauge,
+  TimelineHeatmap,
+} from "@/components/Charts"
 import { calculateNutrientAvailability, calculateStressIndex } from "@/lib/plant-metrics"
+import { generateDailyActivity } from "@/lib/seasonal-trends"
 
 import { getWeatherForUser, type Weather } from "@/lib/weather"
 import { samplePlants } from "@/lib/plants"
@@ -70,6 +76,10 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
   const toast = useToast()
   const [weather, setWeather] = useState<Weather | null>(null)
   const [offline, setOffline] = useState(false)
+  const dailyActivity = useMemo(
+    () => generateDailyActivity(plant?.events || []),
+    [plant?.events]
+  )
 
   function calculateNextDue(lastWatered: string, w: Weather | null): string {
     const date = new Date(`${lastWatered} ${new Date().getFullYear()}`)
@@ -437,6 +447,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
 
               <section>
                 <h2 className="text-lg font-semibold mb-3">Timeline</h2>
+                <TimelineHeatmap activity={dailyActivity} />
                 {!plant.events || plant.events.length === 0 ? (
                   <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
                 ) : (

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -20,6 +20,7 @@ import {
   aggregateCareByMonth,
   aggregateTaskCompletion,
   CareEvent,
+  type DailyActivity,
 } from "@/lib/seasonal-trends"
 import { calculateNutrientAvailability, type StressDatum } from "@/lib/plant-metrics"
 
@@ -264,5 +265,60 @@ export function NutrientLevelChart({
       </LineChart>
 
     </ResponsiveContainer>
+  )
+}
+
+export function TimelineHeatmap({ activity }: { activity: DailyActivity }) {
+  const dates = Object.keys(activity).sort()
+  const types = Array.from(
+    new Set(dates.flatMap((d) => Object.keys(activity[d])))
+  )
+  const counts = dates.flatMap((d) => Object.values(activity[d]))
+  const max = Math.max(1, ...counts, 1)
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="border-collapse">
+        <thead>
+          <tr>
+            <th className="p-1 text-xs"></th>
+            {dates.map((date) => (
+              <th key={date} className="p-1 text-xs">
+                {new Date(date).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {types.map((type) => (
+            <tr key={type}>
+              <td className="p-1 text-xs">{type}</td>
+              {dates.map((date) => {
+                const count = activity[date]?.[type] ?? 0
+                const intensity = count / max
+                return (
+                  <td
+                    key={date}
+                    data-testid="heatmap-cell"
+                    data-count={count}
+                    title={`${type} on ${date}: ${count}`}
+                    style={{
+                      backgroundColor: count
+                        ? `rgba(34,197,94,${intensity})`
+                        : "#e5e7eb",
+                      width: "1rem",
+                      height: "1rem",
+                    }}
+                  />
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/components/__tests__/TimelineHeatmap.test.tsx
+++ b/components/__tests__/TimelineHeatmap.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import { TimelineHeatmap } from '../Charts'
+
+describe('TimelineHeatmap', () => {
+  it('renders cells for each date and type', () => {
+    const activity = {
+      '2024-01-01': { water: 1 },
+      '2024-01-02': { water: 2, fertilize: 1 },
+    }
+    render(<TimelineHeatmap activity={activity} />)
+    expect(screen.getAllByTestId('heatmap-cell')).toHaveLength(4)
+    expect(screen.getByTitle('water on 2024-01-02: 2')).toBeInTheDocument()
+  })
+})

--- a/lib/__tests__/seasonal-trends.test.ts
+++ b/lib/__tests__/seasonal-trends.test.ts
@@ -1,6 +1,7 @@
 import {
   aggregateCareByMonth,
   aggregateTaskCompletion,
+  generateDailyActivity,
 } from '../seasonal-trends'
 
 describe('aggregateCareByMonth', () => {
@@ -28,5 +29,18 @@ describe('aggregateTaskCompletion', () => {
     const result = aggregateTaskCompletion(events)
     expect(result[0]).toEqual({ month: 'Jan', completed: 1, missed: 1 })
     expect(result[1]).toEqual({ month: 'Feb', completed: 1, missed: 0 })
+  })
+})
+
+describe('generateDailyActivity', () => {
+  it('groups counts by date and event type', () => {
+    const events = [
+      { type: 'water', date: '2024-01-15' },
+      { type: 'water', date: '2024-01-15' },
+      { type: 'fertilize', date: '2024-01-16' },
+    ]
+    const result = generateDailyActivity(events)
+    expect(result['2024-01-15']).toEqual({ water: 2 })
+    expect(result['2024-01-16']).toEqual({ fertilize: 1 })
   })
 })

--- a/lib/seasonal-trends.ts
+++ b/lib/seasonal-trends.ts
@@ -1,3 +1,5 @@
+import type { PlantEvent } from "./plants"
+
 const months = [
   "Jan",
   "Feb",
@@ -58,5 +60,19 @@ export function aggregateTaskCompletion(
   }
 
   return totals
+}
+
+export type DailyActivity = Record<string, Record<string, number>>
+
+export function generateDailyActivity(events: PlantEvent[]): DailyActivity {
+  const activity: DailyActivity = {}
+  for (const e of events) {
+    const d = new Date(e.date)
+    if (isNaN(d.getTime())) continue
+    const dateKey = d.toISOString().split("T")[0]
+    if (!activity[dateKey]) activity[dateKey] = {}
+    activity[dateKey][e.type] = (activity[dateKey][e.type] || 0) + 1
+  }
+  return activity
 }
 


### PR DESCRIPTION
## Summary
- add `generateDailyActivity` utility for daily event aggregation
- visualize plant activity with `TimelineHeatmap`
- show daily heatmap on plant detail timeline

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4dc4910c0832498af579a478e78e1