### PR TITLE
Add hydration trend metrics and chart

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -13,6 +13,7 @@ import NoteModal from "@/components/NoteModal"
 import { ToastProvider, useToast } from "@/components/Toast"
 import {
   CareTrendsChart,
+  HydrationTrendChart,
   NutrientLevelChart,
   StressIndexGauge,
   TimelineHeatmap,
@@ -36,6 +37,7 @@ interface Plant {
   species: string
   status: string
   hydration: number
+  hydrationLog?: { date: string; value: number }[]
   lastWatered: string
   nextDue: string
   lastFertilized: string
@@ -431,6 +433,9 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
 
               <h2 className="text-lg font-semibold mb-3">Care Trends</h2>
               <CareTrendsChart events={plant.events} />
+
+              <h2 className="text-lg font-semibold mb-3">Hydration Trend</h2>
+              <HydrationTrendChart log={plant.hydrationLog ?? []} />
 
               <h2 className="text-lg font-semibold mb-3">Care Plan</h2>
               {carePlanLoading ? (

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -14,7 +14,7 @@ import {
   BarChart,
   Bar,
   ComposedChart,
-
+  ReferenceLine,
 } from "recharts"
 import {
   aggregateCareByMonth,
@@ -22,7 +22,12 @@ import {
   CareEvent,
   type DailyActivity,
 } from "@/lib/seasonal-trends"
-import { calculateNutrientAvailability, type StressDatum } from "@/lib/plant-metrics"
+import {
+  calculateNutrientAvailability,
+  calculateHydrationTrend,
+  type StressDatum,
+  type HydrationLogEntry,
+} from "@/lib/plant-metrics"
 
 // Dummy dataset for environment over 7 days
 const envData = [
@@ -100,6 +105,37 @@ export function VPDGauge() {
           1.2 kPa
         </text>
       </RadialBarChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function HydrationTrendChart({
+  log,
+}: {
+  log: HydrationLogEntry[]
+}) {
+  const data = calculateHydrationTrend(log)
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis domain={[0, 100]} />
+        <Tooltip />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="avg"
+          stroke="#3b82f6"
+          name="Hydration (%)"
+        />
+        <ReferenceLine
+          y={40}
+          stroke="#ef4444"
+          strokeDasharray="3 3"
+          label="Low"
+        />
+      </LineChart>
     </ResponsiveContainer>
   )
 }

--- a/lib/__tests__/plant-metrics.test.ts
+++ b/lib/__tests__/plant-metrics.test.ts
@@ -1,4 +1,10 @@
-import { calculateEt0, waterBalanceSeries, WeatherDay, WaterEvent } from '../plant-metrics'
+import {
+  calculateEt0,
+  waterBalanceSeries,
+  WeatherDay,
+  WaterEvent,
+  calculateHydrationTrend,
+} from '../plant-metrics'
 
 describe('plant metrics', () => {
   it('calculates et0 and water balance', () => {
@@ -10,5 +16,17 @@ describe('plant metrics', () => {
     expect(typeof et0).toBe('number')
     const series = waterBalanceSeries(weather, events)
     expect(series).toEqual([{ date: '2024-08-21', et0, water: 5 }])
+  })
+
+  it('computes hydration trend with threshold detection', () => {
+    const log = [
+      { date: '2024-08-01', value: 80 },
+      { date: '2024-08-02', value: 60 },
+      { date: '2024-08-03', value: 40 },
+      { date: '2024-08-04', value: 20 },
+    ]
+    const trend = calculateHydrationTrend(log, 3, 50)
+    expect(trend[2]).toMatchObject({ avg: 60, belowThreshold: false })
+    expect(trend[3].belowThreshold).toBe(true)
   })
 })

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -125,3 +125,42 @@ export function stressTrend(
     stress: calculateStressIndex(r),
   }))
 }
+
+export interface HydrationLogEntry {
+  date: string
+  value: number
+}
+
+export interface HydrationTrendDatum {
+  date: string
+  value: number
+  avg: number
+  belowThreshold: boolean
+}
+
+/**
+ * Calculate rolling averages for hydration readings and flag when the average
+ * falls below a given threshold (default 40%).
+ */
+export function calculateHydrationTrend(
+  log: HydrationLogEntry[],
+  window: number = 3,
+  threshold: number = 40,
+): HydrationTrendDatum[] {
+  const sorted = [...log].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  )
+  return sorted.map((entry, idx) => {
+    const start = Math.max(0, idx - window + 1)
+    const slice = sorted.slice(start, idx + 1)
+    const avg =
+      slice.reduce((sum, e) => sum + e.value, 0) / (slice.length || 1)
+    const rounded = Number(avg.toFixed(2))
+    return {
+      date: entry.date,
+      value: entry.value,
+      avg: rounded,
+      belowThreshold: rounded < threshold,
+    }
+  })
+}

--- a/lib/plants.ts
+++ b/lib/plants.ts
@@ -10,6 +10,7 @@ export interface Plant {
   species: string
   status: string
   hydration: number
+  hydrationLog: { date: string; value: number }[]
   lastWatered: string
   nextDue: string
   lastFertilized: string
@@ -25,6 +26,11 @@ export const samplePlants: Record<string, Plant> = {
     species: "Monstera deliciosa",
     status: "Water overdue",
     hydration: 72,
+    hydrationLog: [
+      { date: "2024-08-21", value: 80 },
+      { date: "2024-08-24", value: 75 },
+      { date: "2024-08-27", value: 72 },
+    ],
     lastWatered: "Aug 25",
     lastFertilized: "Aug 10",
     nextDue: "Aug 30",
@@ -43,6 +49,11 @@ export const samplePlants: Record<string, Plant> = {
     species: "Sansevieria trifasciata",
     status: "Fine",
     hydration: 90,
+    hydrationLog: [
+      { date: "2024-08-22", value: 92 },
+      { date: "2024-08-25", value: 91 },
+      { date: "2024-08-28", value: 90 },
+    ],
     lastWatered: "Aug 27",
     lastFertilized: "Aug 01",
     nextDue: "Sep 5",
@@ -55,6 +66,11 @@ export const samplePlants: Record<string, Plant> = {
     species: "Epipremnum aureum",
     status: "Due today",
     hydration: 70,
+    hydrationLog: [
+      { date: "2024-08-21", value: 72 },
+      { date: "2024-08-24", value: 71 },
+      { date: "2024-08-27", value: 70 },
+    ],
     lastWatered: "Aug 28",
     lastFertilized: "Aug 18",
     nextDue: "Aug 29",
@@ -67,6 +83,11 @@ export const samplePlants: Record<string, Plant> = {
     species: "Ficus lyrata",
     status: "Fertilize suggested",
     hydration: 75,
+    hydrationLog: [
+      { date: "2024-08-21", value: 78 },
+      { date: "2024-08-24", value: 76 },
+      { date: "2024-08-27", value: 75 },
+    ],
     lastWatered: "Aug 23",
     lastFertilized: "Aug 15",
     nextDue: "Sep 2",


### PR DESCRIPTION
## Summary
- track hydration over time with new `hydrationLog` field on plants
- compute rolling hydration averages with `calculateHydrationTrend`
- visualize hydration trends in plant dashboard

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e1e53f548324bcb1c525e4e7e098