### PR TITLE
feat: add plant health radar chart

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   NutrientLevelChart,
   StressIndexGauge,
   TimelineHeatmap,
+  PlantHealthRadar,
 } from "@/components/Charts"
 import { calculateNutrientAvailability, calculateStressIndex } from "@/lib/plant-metrics"
 import { generateDailyActivity } from "@/lib/seasonal-trends"
@@ -428,7 +429,18 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
             </section>
 
             <section>
+              <h2 className="text-lg font-semibold mb-3">Plant Health</h2>
+              <PlantHealthRadar
+                hydration={plant.hydration}
+                lastFertilized={plant.lastFertilized}
+                nutrientLevel={plant.nutrientLevel ?? 100}
+                events={plant.events}
+                status={plant.status}
+                weather={weather}
+              />
+            </section>
 
+            <section>
               <h2 className="text-lg font-semibold mb-3">Care Trends</h2>
               <CareTrendsChart events={plant.events} />
 

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -14,7 +14,11 @@ import {
   BarChart,
   Bar,
   ComposedChart,
-
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
 } from "recharts"
 import {
   aggregateCareByMonth,
@@ -22,7 +26,12 @@ import {
   CareEvent,
   type DailyActivity,
 } from "@/lib/seasonal-trends"
-import { calculateNutrientAvailability, type StressDatum } from "@/lib/plant-metrics"
+import {
+  calculateNutrientAvailability,
+  calculateStressIndex,
+  type StressDatum,
+} from "@/lib/plant-metrics"
+import type { Weather } from "@/lib/weather"
 
 // Dummy dataset for environment over 7 days
 const envData = [
@@ -264,6 +273,53 @@ export function NutrientLevelChart({
         <Line type="monotone" dataKey="level" stroke="#16a34a" name="Nutrients (%)" />
       </LineChart>
 
+    </ResponsiveContainer>
+  )
+}
+
+export function PlantHealthRadar({
+  hydration,
+  lastFertilized,
+  nutrientLevel = 100,
+  events,
+  status,
+  weather,
+}: {
+  hydration: number
+  lastFertilized: string
+  nutrientLevel?: number
+  events: CareEvent[]
+  status: string
+  weather: Weather | null
+}) {
+  const nutrients = calculateNutrientAvailability(lastFertilized, nutrientLevel)
+  const light = Math.min(100, (weather?.solarRadiation ?? 50) * 4)
+  const stress = calculateStressIndex({
+    overdueDays: status === "Water overdue" ? 1 : 0,
+    hydration,
+    temperature: weather?.temperature ?? 25,
+    light,
+  })
+  const totals = aggregateTaskCompletion(events)
+  const completed = totals.reduce((sum, t) => sum + t.completed, 0)
+  const missed = totals.reduce((sum, t) => sum + t.missed, 0)
+  const consistency = completed + missed ? (completed / (completed + missed)) * 100 : 0
+  const data = [
+    { metric: "Hydration", value: hydration },
+    { metric: "Nutrients", value: nutrients },
+    { metric: "Light", value: light },
+    { metric: "Stress", value: stress },
+    { metric: "Consistency", value: consistency },
+  ]
+
+  return (
+    <ResponsiveContainer width={180} height={140}>
+      <RadarChart cx="50%" cy="50%" outerRadius="80%" data={data}>
+        <PolarGrid stroke="#e5e7eb" />
+        <PolarAngleAxis dataKey="metric" stroke="#6b7280" />
+        <PolarRadiusAxis angle={30} domain={[0, 100]} tick={false} />
+        <Radar dataKey="value" stroke="#64748b" fill="#94a3b8" fillOpacity={0.3} />
+      </RadarChart>
     </ResponsiveContainer>
   )
 }


### PR DESCRIPTION
## Summary
- add PlantHealthRadar chart to visualize hydration, nutrients, light, stress and care consistency
- render PlantHealthRadar on plant detail page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e1d94ca0832489298dfbcab1df35