### PR TITLE
Import missing hydration helpers

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -30,8 +30,10 @@ import {
   type DailyActivity,
 } from "@/lib/seasonal-trends"
 import {
+  calculateHydrationTrend,
   calculateNutrientAvailability,
   calculateStressIndex,
+  type HydrationLogEntry,
   type StressDatum,
 } from "@/lib/plant-metrics"
 import type { Weather } from "@/lib/weather"


### PR DESCRIPTION
## Summary
- import `calculateHydrationTrend` and its `HydrationLogEntry` type into `Charts`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4e3d6cb5c83248811fcaf8cb0adf9