### PR TITLE
Add plant comparison utilities and charts

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -8,16 +8,19 @@ import {
   StressIndexGauge,
   StressIndexChart,
   TaskCompletionChart,
+  ComparativeChart,
 } from "@/components/Charts"
 import {
   waterBalanceSeries,
   WeatherDay,
   WaterEvent,
   stressTrend,
+  collectPlantMetrics,
 } from "@/lib/plant-metrics"
 import { CareEvent } from "@/lib/seasonal-trends"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
+import { samplePlants } from "@/lib/plants"
 
 export default function SciencePanel() {
   const readings = { temperature: 75, humidity: 52, vpd: 1.2 }
@@ -102,6 +105,9 @@ export default function SciencePanel() {
   const stressData = stressTrend(stressReadings)
   const currentStress = stressData[stressData.length - 1]?.stress ?? 0
 
+  const plants = Object.values(samplePlants)
+  const comparisonData = collectPlantMetrics(plants)
+
   const taskEvents: CareEvent[] = [
     { date: "2024-01-05", type: "completed" },
     { date: "2024-01-12", type: "missed" },
@@ -169,6 +175,11 @@ export default function SciencePanel() {
           <StressIndexGauge value={currentStress} />
           <StressIndexChart data={stressData} />
         </div>
+      </section>
+
+      <section className="mt-4 md:mt-6">
+        <h3 className="font-medium text-gray-800">Plant Comparison</h3>
+        <ComparativeChart plants={plants} data={comparisonData} />
       </section>
 
       <section className="mt-4 md:mt-6">

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -32,8 +32,12 @@ import {
 import {
   calculateNutrientAvailability,
   calculateStressIndex,
+  calculateHydrationTrend,
   type StressDatum,
+  type HydrationLogEntry,
+  type ComparativeDatum,
 } from "@/lib/plant-metrics"
+import type { Plant } from "@/lib/plants"
 import type { Weather } from "@/lib/weather"
 
 
@@ -143,6 +147,47 @@ export function HydrationTrendChart({
           strokeDasharray="3 3"
           label="Low"
         />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function ComparativeChart({
+  plants,
+  data,
+}: {
+  plants: Plant[]
+  data: ComparativeDatum[]
+}) {
+  const colors = [
+    "#3b82f6",
+    "#ef4444",
+    "#16a34a",
+    "#f59e0b",
+    "#8b5cf6",
+    "#ec4899",
+    "#0ea5e9",
+    "#fde047",
+  ]
+
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis domain={[0, 100]} />
+        <Tooltip />
+        <Legend />
+        {plants.map((p, idx) => (
+          <Line
+            key={p.nickname}
+            type="monotone"
+            dataKey={p.nickname}
+            stroke={colors[idx % colors.length]}
+            name={p.nickname}
+            data-testid={`comparative-line-${idx}`}
+          />
+        ))}
       </LineChart>
     </ResponsiveContainer>
   )

--- a/components/__tests__/ComparativeChart.test.tsx
+++ b/components/__tests__/ComparativeChart.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { ComparativeChart } from '../Charts'
+import { collectPlantMetrics } from '@/lib/plant-metrics'
+import { samplePlants } from '@/lib/plants'
+
+jest.mock('recharts', () => {
+  const original = jest.requireActual('recharts')
+  const React = require('react')
+  return {
+    ...original,
+    ResponsiveContainer: ({ children }: any) => (
+      <div style={{ width: 400, height: 300 }}>
+        {React.cloneElement(children, { width: 400, height: 300 })}
+      </div>
+    ),
+  }
+})
+
+describe('ComparativeChart', () => {
+  it('renders a line for each plant', () => {
+    const plants = [samplePlants['1'], samplePlants['2']]
+    const data = collectPlantMetrics(plants)
+    render(<ComparativeChart plants={plants} data={data} />)
+    const lines = screen.getAllByTestId(/comparative-line-/)
+    expect(lines).toHaveLength(plants.length)
+    const strokes = lines.map((l) => l.getAttribute('stroke'))
+    expect(new Set(strokes).size).toBe(plants.length)
+  })
+})

--- a/lib/__tests__/plant-metrics.test.ts
+++ b/lib/__tests__/plant-metrics.test.ts
@@ -4,7 +4,9 @@ import {
   WeatherDay,
   WaterEvent,
   calculateHydrationTrend,
+  collectPlantMetrics,
 } from '../plant-metrics'
+import { samplePlants } from '../plants'
 
 describe('plant metrics', () => {
   it('calculates et0 and water balance', () => {
@@ -28,5 +30,12 @@ describe('plant metrics', () => {
     const trend = calculateHydrationTrend(log, 3, 50)
     expect(trend[2]).toMatchObject({ avg: 60, belowThreshold: false })
     expect(trend[3].belowThreshold).toBe(true)
+  })
+
+  it('collects hydration metrics across plants', () => {
+    const plants = [samplePlants['1'], samplePlants['2']]
+    const metrics = collectPlantMetrics(plants)
+    expect(metrics[0]).toMatchObject({ date: '2024-08-21', Delilah: 80 })
+    expect(metrics.some((m) => m.Sunny === 92)).toBe(true)
   })
 })

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -1,3 +1,5 @@
+import type { Plant } from "./plants"
+
 export interface WeatherDay {
   date: string
   temperature: number // °C
@@ -162,5 +164,39 @@ export function calculateHydrationTrend(
       avg: rounded,
       belowThreshold: rounded < threshold,
     }
+  })
+}
+
+export interface ComparativeDatum {
+  date: string
+  [plant: string]: number | null | undefined
+}
+
+/**
+ * Collect hydration values across multiple plants and align them by date.
+ *
+ * The returned array contains one entry per unique date found in any plant's
+ * hydration log. Each object has a `date` property and a property for each
+ * plant's nickname holding the hydration value (or `null` if no reading was
+ * recorded that day).
+ */
+export function collectPlantMetrics(plants: Plant[]): ComparativeDatum[] {
+  const dates = new Set<string>()
+  plants.forEach((p) =>
+    p.hydrationLog.forEach((h) => {
+      dates.add(h.date)
+    }),
+  )
+  const sortedDates = Array.from(dates).sort(
+    (a, b) => new Date(a).getTime() - new Date(b).getTime(),
+  )
+
+  return sortedDates.map((date) => {
+    const datum: ComparativeDatum = { date }
+    plants.forEach((p) => {
+      const entry = p.hydrationLog.find((h) => h.date === date)
+      datum[p.nickname] = entry ? entry.value : null
+    })
+    return datum
   })
 }


### PR DESCRIPTION
## Summary
- add `collectPlantMetrics` helper to combine hydration logs across plants
- implement `ComparativeChart` to plot multi-plant hydration trends with distinct colors
- surface plant comparison chart on science dashboard

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e36a68f0832499db3812b04ba5a9