### PR TITLE
feat: add standardized panel component and typography

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -11,6 +11,7 @@ import WaterModal from "@/components/WaterModal"
 import FertilizeModal from "@/components/FertilizeModal"
 import NoteModal from "@/components/NoteModal"
 import { ToastProvider, useToast } from "@/components/Toast"
+import Panel from "@/components/Panel"
 import {
   CareTrendsChart,
   HydrationTrendChart,
@@ -318,7 +319,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
         ) : (
           <>
 
-            <section className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+            <Panel label="Overview" className="flex flex-col md:flex-row gap-6 items-center md:items-start">
               {plant.photos && plant.photos.length > 0 ? (
                 <Image
                   src={plant.photos[0]}
@@ -389,9 +390,9 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
                   Last fertilized: <strong>{plant.lastFertilized}</strong> · Next feed: <strong>{calculateNextFeedDate(plant.lastFertilized, plant.nutrientLevel ?? 100)}</strong>
                 </p>
               </div>
-            </section>
+            </Panel>
 
-            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+            <Panel label="Stats" className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
               {[
                 { label: "Status", value: plant.status },
                 { label: "Hydration", value: `${plant.hydration}%` },
@@ -408,10 +409,8 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
                   <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
                 </div>
               ))}
-            </section>
-
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Stress Level</h2>
+            </Panel>
+            <Panel label="Stress Level">
               <StressIndexGauge
                 value={calculateStressIndex({
                   overdueDays: plant.status === "Water overdue" ? 1 : 0,
@@ -420,18 +419,16 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
                   light: 50,
                 })}
               />
-            </section>
+            </Panel>
 
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Nutrient Levels</h2>
+            <Panel label="Nutrient Levels">
               <NutrientLevelChart
                 lastFertilized={plant.lastFertilized}
                 nutrientLevel={plant.nutrientLevel ?? 100}
               />
-            </section>
+            </Panel>
 
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Plant Health</h2>
+            <Panel label="Plant Health">
               <PlantHealthRadar
                 hydration={plant.hydration}
                 lastFertilized={plant.lastFertilized}
@@ -440,16 +437,17 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
                 status={plant.status}
                 weather={weather}
               />
-            </section>
+            </Panel>
 
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Care Trends</h2>
+            <Panel label="Care Trends">
               <CareTrendsChart events={plant.events} />
+            </Panel>
 
-              <h2 className="text-lg font-semibold mb-3">Hydration Trend</h2>
+            <Panel label="Hydration Trend">
               <HydrationTrendChart log={plant.hydrationLog ?? []} />
+            </Panel>
 
-              <h2 className="text-lg font-semibold mb-3">Care Plan</h2>
+            <Panel label="Care Plan">
               {carePlanLoading ? (
                 <p className="text-sm text-gray-500 dark:text-gray-400">Generating care plan...</p>
               ) : carePlanError ? (
@@ -459,49 +457,46 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               ) : (
                 <p className="text-sm text-gray-500 dark:text-gray-400">No care plan available.</p>
               )}
+            </Panel>
 
-            </section>
-
-              <section>
-                <h2 className="text-lg font-semibold mb-3">Timeline</h2>
-                <TimelineHeatmap activity={dailyActivity} />
-                {!plant.events || plant.events.length === 0 ? (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
-                ) : (
-                  <ul className="space-y-2">
-                    {plant.events
-                      .filter((e): e is PlantEvent => e !== null && e !== undefined)
-                      .map((e) => {
-                        const type =
-                          EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
-                        const Icon = type.icon
-                        return (
-                          <li
-                            key={e.id}
-                            className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
-                          >
-                            <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
-                            <span className="text-sm flex items-center gap-2">
-                              <span
-                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ${type.color}`}
-                              >
-                                <span aria-hidden="true">
-                                  <Icon className="h-3 w-3" />
-                                </span>
-                                <span aria-hidden="true">{type.label}</span>
-                                <span className="sr-only">{type.label}</span>
+            <Panel label="Timeline">
+              <TimelineHeatmap activity={dailyActivity} />
+              {!plant.events || plant.events.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {plant.events
+                    .filter((e): e is PlantEvent => e !== null && e !== undefined)
+                    .map((e) => {
+                      const type =
+                        EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
+                      const Icon = type.icon
+                      return (
+                        <li
+                          key={e.id}
+                          className="flex items-start gap-3 rounded-lg border p-3 bg-white dark:bg-gray-900 dark:border-gray-700"
+                        >
+                          <span className="w-16 text-xs font-medium text-gray-500">{e.date}</span>
+                          <span className="text-sm flex items-center gap-2">
+                            <span
+                              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ${type.color}`}
+                            >
+                              <span aria-hidden="true">
+                                <Icon className="h-3 w-3" />
                               </span>
-                              {e.type === "note" && e.note}
+                              <span aria-hidden="true">{type.label}</span>
+                              <span className="sr-only">{type.label}</span>
                             </span>
-                          </li>
-                        )
-                      })}
-                  </ul>
-                )}
-              </section>
+                            {e.type === "note" && e.note}
+                          </span>
+                        </li>
+                      )
+                    })}
+                </ul>
+              )}
+            </Panel>
 
-            <section>
-              <h2 className="text-lg font-semibold mb-3">Gallery</h2>
+            <Panel label="Gallery">
               {plant.photos && plant.photos.length > 0 ? (
                 <Lightbox
                   images={plant.photos.map((src, i) => ({
@@ -512,7 +507,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               ) : (
                 <p className="text-sm text-gray-500 dark:text-gray-400">No photos available.</p>
               )}
-            </section>
+            </Panel>
           </>
         )}
       </div>

--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
 import { CareTrendsChart } from "@/components/Charts"
+import Panel from "@/components/Panel"
 
 const sampleRooms = {
   "living-room": {
@@ -61,8 +62,7 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
               <p className="text-gray-500">{room.tasks} tasks due</p>
             </header>
 
-            <section>
-              <h2 className="font-semibold mb-2">Plants</h2>
+            <Panel label="Plants" className="space-y-2">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {room.plants.map((p) => (
                   <Link key={p.id} href={`/plants/${p.id}`} className="block">
@@ -70,12 +70,11 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
                   </Link>
                 ))}
               </div>
-            </section>
+            </Panel>
 
-            <section>
-              <h2 className="font-semibold mb-2">Care Trends</h2>
+            <Panel label="Care Trends">
               <CareTrendsChart events={room.events ?? []} />
-            </section>
+            </Panel>
           </>
         )}
       </div>

--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -18,6 +18,7 @@ import {
 import { CareEvent } from "@/lib/seasonal-trends"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
+import Panel from "@/components/Panel"
 
 export default function SciencePanel() {
   const readings = { temperature: 75, humidity: 52, vpd: 1.2 }
@@ -125,8 +126,7 @@ export default function SciencePanel() {
         </button>
       </header>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Environment Data</h3>
+      <Panel label="Environment Data" className="mt-4 md:mt-6">
         <EnvRow
           temperature={readings.temperature}
           humidity={readings.humidity}
@@ -134,15 +134,13 @@ export default function SciencePanel() {
           tempUnit={tempUnit}
         />
         <TempHumidityChart tempUnit={tempUnit} />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">VPD Gauge</h3>
+      <Panel label="VPD Gauge" className="mt-4 md:mt-6">
         <VPDGauge />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Water Balance</h3>
+      <Panel label="Water Balance" className="mt-4 md:mt-6">
         <div className="flex items-center gap-2 mb-2">
           <label
             htmlFor="watering-interval"
@@ -161,20 +159,18 @@ export default function SciencePanel() {
           />
         </div>
         <WaterBalanceChart data={waterData} />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Plant Stress</h3>
+      <Panel label="Plant Stress" className="mt-4 md:mt-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <StressIndexGauge value={currentStress} />
           <StressIndexChart data={stressData} />
         </div>
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Task Completion</h3>
+      <Panel label="Task Completion" className="mt-4 md:mt-6">
         <TaskCompletionChart events={taskEvents} />
-      </section>
+      </Panel>
 
       <Footer />
     </main>

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -32,6 +32,7 @@ import {
 import {
   calculateNutrientAvailability,
   calculateStressIndex,
+  calculateHydrationTrend,
   type StressDatum,
 } from "@/lib/plant-metrics"
 import type { Weather } from "@/lib/weather"
@@ -63,12 +64,12 @@ export function TempHumidityChart({
 
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <LineChart data={data}>
+      <LineChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="day" />
-        <YAxis />
+        <XAxis dataKey="day" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Line
           type="monotone"
           dataKey="temp"
@@ -96,6 +97,7 @@ export function VPDGauge() {
         data={vpdData}
         startAngle={180}
         endAngle={0}
+        className="text-xs font-sans"
       >
         <RadialBar
           minAngle={15}
@@ -108,7 +110,7 @@ export function VPDGauge() {
           y="50%"
           textAnchor="middle"
           dominantBaseline="middle"
-          className="text-lg fill-gray-700"
+          className="text-lg font-mono fill-gray-700"
         >
           1.2 kPa
         </text>
@@ -125,12 +127,12 @@ export function HydrationTrendChart({
   const data = calculateHydrationTrend(log)
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <LineChart data={data}>
+      <LineChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis domain={[0, 100]} tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Line
           type="monotone"
           dataKey="avg"
@@ -153,12 +155,12 @@ export function CareTrendsChart({ events }: { events: CareEvent[] }) {
 
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <BarChart data={data}>
+      <BarChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="month" />
-        <YAxis allowDecimals={false} />
+        <XAxis dataKey="month" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis allowDecimals={false} tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Bar dataKey="water" fill="#3b82f6" name="Water" />
         <Bar dataKey="fertilize" fill="#22c55e" name="Fertilize" />
       </BarChart>
@@ -178,12 +180,12 @@ export function TaskCompletionChart({ events }: { events: CareEvent[] }) {
 
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <LineChart data={data}>
+      <LineChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="month" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="month" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis domain={[0, 100]} tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Line
           type="monotone"
           dataKey="completed"
@@ -210,12 +212,12 @@ export interface WaterBalanceDatum {
 export function WaterBalanceChart({ data }: { data: WaterBalanceDatum[] }) {
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <ComposedChart data={data}>
+      <ComposedChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis />
+        <XAxis dataKey="date" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Bar dataKey="water" fill="#3b82f6" name="Water (mm)" />
         <Line
           type="monotone"
@@ -242,6 +244,7 @@ export function StressIndexGauge({ value }: { value: number }) {
         data={data}
         startAngle={180}
         endAngle={0}
+        className="text-xs font-sans"
       >
         <RadialBar minAngle={15} background clockWise dataKey="value" />
         <text
@@ -249,7 +252,7 @@ export function StressIndexGauge({ value }: { value: number }) {
           y="50%"
           textAnchor="middle"
           dominantBaseline="middle"
-          className="text-lg fill-gray-700"
+          className="text-lg font-mono fill-gray-700"
         >
           {value}
         </text>
@@ -262,12 +265,12 @@ export function StressIndexGauge({ value }: { value: number }) {
 export function StressIndexChart({ data }: { data: StressDatum[] }) {
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <LineChart data={data}>
+      <LineChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis domain={[0, 100]} tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Line type="monotone" dataKey="stress" stroke="#ef4444" name="Stress" />
       </LineChart>
     </ResponsiveContainer>
@@ -299,12 +302,12 @@ export function NutrientLevelChart({
 
   return (
     <ResponsiveContainer width="100%" height={250}>
-      <LineChart data={data}>
+      <LineChart data={data} className="text-xs font-sans">
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="day" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="day" tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
+        <YAxis domain={[0, 100]} tick={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={{ fontSize: 12, fontFamily: 'var(--font-sans)' }} />
         <Line type="monotone" dataKey="level" stroke="#16a34a" name="Nutrients (%)" />
       </LineChart>
 
@@ -349,7 +352,7 @@ export function PlantHealthRadar({
 
   return (
     <ResponsiveContainer width={180} height={140}>
-      <RadarChart cx="50%" cy="50%" outerRadius="80%" data={data}>
+      <RadarChart cx="50%" cy="50%" outerRadius="80%" data={data} className="text-xs font-sans">
         <PolarGrid stroke="#e5e7eb" />
         <PolarAngleAxis dataKey="metric" stroke="#6b7280" />
         <PolarRadiusAxis angle={30} domain={[0, 100]} tick={false} />
@@ -369,12 +372,12 @@ export function TimelineHeatmap({ activity }: { activity: DailyActivity }) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="border-collapse">
+      <table className="border-collapse font-sans text-xs">
         <thead>
           <tr>
-            <th className="p-1 text-xs"></th>
+            <th className="p-1"></th>
             {dates.map((date) => (
-              <th key={date} className="p-1 text-xs">
+              <th key={date} className="p-1">
                 {new Date(date).toLocaleDateString(undefined, {
                   month: "short",
                   day: "numeric",
@@ -386,7 +389,7 @@ export function TimelineHeatmap({ activity }: { activity: DailyActivity }) {
         <tbody>
           {types.map((type) => (
             <tr key={type}>
-              <td className="p-1 text-xs">{type}</td>
+              <td className="p-1">{type}</td>
               {dates.map((date) => {
                 const count = activity[date]?.[type] ?? 0
                 const intensity = count / max

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+
+interface PanelProps {
+  label: string
+  children: React.ReactNode
+  className?: string
+}
+
+export default function Panel({ label, children, className = "" }: PanelProps) {
+  return (
+    <section className={`border rounded bg-gray-50 p-4 md:p-6 ${className}`}>
+      <h3 className="font-mono text-sm text-gray-700 mb-2">{label}</h3>
+      {children}
+    </section>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,6 +29,20 @@ const config: Config = {
         xl: "1.25rem",
         "2xl": "1.5rem",
       },
+      fontFamily: {
+        sans: [
+          '"Source Sans Pro"',
+          'ui-sans-serif',
+          'system-ui',
+          'sans-serif',
+        ],
+        mono: [
+          '"IBM Plex Mono"',
+          'ui-monospace',
+          'SFMono-Regular',
+          'monospace',
+        ],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- build Panel wrapper with border, rounded corners, gray background and mono heading for lab modules
- swap raw sections in dashboard views for new Panel component
- refine Tailwind font families and update chart axis/legend typography for consistency

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e35dc9388324871b9be9eea22256