### PR TITLE
Remove redundant hydration trend import

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -33,7 +33,6 @@ import {
   calculateHydrationTrend,
   calculateNutrientAvailability,
   calculateStressIndex,
-  calculateHydrationTrend,
 
   type StressDatum,
   type HydrationLogEntry,


### PR DESCRIPTION
## Summary
- fix duplicate `calculateHydrationTrend` import in Charts module

## Testing
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68b4e59073908324bb221fa9e89d2a50