### PR TITLE
feat: unify lab module styling and fonts

### DIFF
--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
 import { CareTrendsChart } from "@/components/Charts"
+import Panel from "@/components/Panel"
 
 const sampleRooms = {
   "living-room": {
@@ -61,21 +62,24 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
               <p className="text-gray-500">{room.tasks} tasks due</p>
             </header>
 
-            <section>
-              <h2 className="font-semibold mb-2">Plants</h2>
+            <Panel label="Plants">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {room.plants.map((p) => (
                   <Link key={p.id} href={`/plants/${p.id}`} className="block">
-                    <PlantCard nickname={p.nickname} species={p.species} status={p.status} hydration={p.hydration} />
+                    <PlantCard
+                      nickname={p.nickname}
+                      species={p.species}
+                      status={p.status}
+                      hydration={p.hydration}
+                    />
                   </Link>
                 ))}
               </div>
-            </section>
+            </Panel>
 
-            <section>
-              <h2 className="font-semibold mb-2">Care Trends</h2>
+            <Panel label="Care Trends">
               <CareTrendsChart events={room.events ?? []} />
-            </section>
+            </Panel>
           </>
         )}
       </div>

--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -20,6 +20,7 @@ import {
 import { CareEvent } from "@/lib/seasonal-trends"
 import EnvRow from "@/components/EnvRow"
 import Footer from "@/components/Footer"
+import Panel from "@/components/Panel"
 import { samplePlants } from "@/lib/plants"
 
 export default function SciencePanel() {
@@ -131,8 +132,7 @@ export default function SciencePanel() {
         </button>
       </header>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Environment Data</h3>
+      <Panel label="Environment Data">
         <EnvRow
           temperature={readings.temperature}
           humidity={readings.humidity}
@@ -140,15 +140,13 @@ export default function SciencePanel() {
           tempUnit={tempUnit}
         />
         <TempHumidityChart tempUnit={tempUnit} />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">VPD Gauge</h3>
+      <Panel label="VPD Gauge">
         <VPDGauge />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Water Balance</h3>
+      <Panel label="Water Balance">
         <div className="flex items-center gap-2 mb-2">
           <label
             htmlFor="watering-interval"
@@ -167,25 +165,22 @@ export default function SciencePanel() {
           />
         </div>
         <WaterBalanceChart data={waterData} />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Plant Stress</h3>
+      <Panel label="Plant Stress">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <StressIndexGauge value={currentStress} />
           <StressIndexChart data={stressData} />
         </div>
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Plant Comparison</h3>
+      <Panel label="Plant Comparison">
         <ComparativeChart plants={plants} data={comparisonData} />
-      </section>
+      </Panel>
 
-      <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Task Completion</h3>
+      <Panel label="Task Completion">
         <TaskCompletionChart events={taskEvents} />
-      </section>
+      </Panel>
 
       <Footer />
     </main>

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -33,7 +33,6 @@ import {
   calculateHydrationTrend,
   calculateNutrientAvailability,
   calculateStressIndex,
-  calculateHydrationTrend,
 
   type StressDatum,
   type HydrationLogEntry,
@@ -42,6 +41,17 @@ import {
 import type { Plant } from "@/lib/plants"
 import type { Weather } from "@/lib/weather"
 
+const axisTickStyle = {
+  fill: "#374151",
+  fontSize: 12,
+  fontFamily: "Helvetica Neue, Arial, sans-serif",
+}
+
+const legendStyle = {
+  fontSize: 12,
+  color: "#374151",
+  fontFamily: "Helvetica Neue, Arial, sans-serif",
+}
 
 // Dummy dataset for environment over 7 days
 const envData = [
@@ -71,10 +81,10 @@ export function TempHumidityChart({
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="day" />
-        <YAxis />
+        <XAxis dataKey="day" tick={axisTickStyle} />
+        <YAxis tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Line
           type="monotone"
           dataKey="temp"
@@ -114,7 +124,7 @@ export function VPDGauge() {
           y="50%"
           textAnchor="middle"
           dominantBaseline="middle"
-          className="text-lg fill-gray-700"
+          className="text-lg font-sans fill-gray-700"
         >
           1.2 kPa
         </text>
@@ -133,10 +143,10 @@ export function HydrationTrendChart({
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tick={axisTickStyle} />
+        <YAxis domain={[0, 100]} tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Line
           type="monotone"
           dataKey="avg"
@@ -176,10 +186,10 @@ export function ComparativeChart({
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tick={axisTickStyle} />
+        <YAxis domain={[0, 100]} tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         {plants.map((p, idx) => (
           <Line
             key={p.nickname}
@@ -202,10 +212,10 @@ export function CareTrendsChart({ events }: { events: CareEvent[] }) {
     <ResponsiveContainer width="100%" height={250}>
       <BarChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="month" />
-        <YAxis allowDecimals={false} />
+        <XAxis dataKey="month" tick={axisTickStyle} />
+        <YAxis allowDecimals={false} tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Bar dataKey="water" fill="#3b82f6" name="Water" />
         <Bar dataKey="fertilize" fill="#22c55e" name="Fertilize" />
       </BarChart>
@@ -227,10 +237,10 @@ export function TaskCompletionChart({ events }: { events: CareEvent[] }) {
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="month" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="month" tick={axisTickStyle} />
+        <YAxis domain={[0, 100]} tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Line
           type="monotone"
           dataKey="completed"
@@ -259,10 +269,10 @@ export function WaterBalanceChart({ data }: { data: WaterBalanceDatum[] }) {
     <ResponsiveContainer width="100%" height={250}>
       <ComposedChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis />
+        <XAxis dataKey="date" tick={axisTickStyle} />
+        <YAxis tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Bar dataKey="water" fill="#3b82f6" name="Water (mm)" />
         <Line
           type="monotone"
@@ -296,7 +306,7 @@ export function StressIndexGauge({ value }: { value: number }) {
           y="50%"
           textAnchor="middle"
           dominantBaseline="middle"
-          className="text-lg fill-gray-700"
+          className="text-lg font-sans fill-gray-700"
         >
           {value}
         </text>
@@ -311,10 +321,10 @@ export function StressIndexChart({ data }: { data: StressDatum[] }) {
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tick={axisTickStyle} />
+        <YAxis domain={[0, 100]} tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Line type="monotone" dataKey="stress" stroke="#ef4444" name="Stress" />
       </LineChart>
     </ResponsiveContainer>
@@ -348,10 +358,10 @@ export function NutrientLevelChart({
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="day" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="day" tick={axisTickStyle} />
+        <YAxis domain={[0, 100]} tick={axisTickStyle} />
         <Tooltip />
-        <Legend />
+        <Legend wrapperStyle={legendStyle} />
         <Line type="monotone" dataKey="level" stroke="#16a34a" name="Nutrients (%)" />
       </LineChart>
 
@@ -398,7 +408,11 @@ export function PlantHealthRadar({
     <ResponsiveContainer width={180} height={140}>
       <RadarChart cx="50%" cy="50%" outerRadius="80%" data={data}>
         <PolarGrid stroke="#e5e7eb" />
-        <PolarAngleAxis dataKey="metric" stroke="#6b7280" />
+        <PolarAngleAxis
+          dataKey="metric"
+          stroke="#6b7280"
+          tick={{ ...axisTickStyle }}
+        />
         <PolarRadiusAxis angle={30} domain={[0, 100]} tick={false} />
         <Radar dataKey="value" stroke="#64748b" fill="#94a3b8" fillOpacity={0.3} />
       </RadarChart>

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+interface PanelProps {
+  label: string
+  children: React.ReactNode
+  className?: string
+}
+
+export default function Panel({ label, children, className }: PanelProps) {
+  return (
+    <section
+      className={`mt-4 md:mt-6 border rounded bg-gray-50 dark:bg-gray-800 p-4 ${
+        className ?? ""
+      }`}
+    >
+      <h3 className="font-mono text-sm text-gray-700 dark:text-gray-300 mb-2">
+        {label}
+      </h3>
+      {children}
+    </section>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss"
+import defaultTheme from "tailwindcss/defaultTheme"
 
 const config: Config = {
   darkMode: ["class"],
@@ -20,6 +21,10 @@ const config: Config = {
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+      },
+      fontFamily: {
+        sans: ["Helvetica Neue", "Arial", ...defaultTheme.fontFamily.sans],
+        mono: ["IBM Plex Mono", ...defaultTheme.fontFamily.mono],
       },
       fontSize: {
         xs: "0.75rem",


### PR DESCRIPTION
## Summary
- add reusable Panel wrapper for lab-style modules
- switch science and room views to Panel and research fonts
- align chart axis and legend typography

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e4f111608324b8fd273a89e0177d