### PR TITLE
feat: enhance plant card visuals

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -73,7 +73,8 @@ export default function TodayPage() {
                   species={p.species}
                   status={p.status}
                   hydration={p.hydration}
-                  hydrationHistory={[p.hydration - 5, p.hydration, Math.min(100, p.hydration + 5)]}
+                  photo={p.photos[0]}
+                  hydrationHistory={p.hydrationLog.map((h) => h.value)}
                 />
               </Link>
             ))}

--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import PlantCard from "@/components/PlantCard"
 import { CareTrendsChart } from "@/components/Charts"
+import { samplePlants } from "@/lib/plants"
 
 const sampleRooms = {
   "living-room": {
@@ -64,11 +65,21 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
             <section>
               <h2 className="font-semibold mb-2">Plants</h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {room.plants.map((p) => (
-                  <Link key={p.id} href={`/plants/${p.id}`} className="block">
-                    <PlantCard nickname={p.nickname} species={p.species} status={p.status} hydration={p.hydration} />
-                  </Link>
-                ))}
+                {room.plants.map((p) => {
+                  const sample = samplePlants[p.id as keyof typeof samplePlants]
+                  return (
+                    <Link key={p.id} href={`/plants/${p.id}`} className="block">
+                      <PlantCard
+                        nickname={p.nickname}
+                        species={p.species}
+                        status={p.status}
+                        hydration={p.hydration}
+                        photo={sample?.photos[0]}
+                        hydrationHistory={sample?.hydrationLog.map((h) => h.value)}
+                      />
+                    </Link>
+                  )
+                })}
               </div>
             </section>
 

--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -12,6 +12,7 @@ type PlantCardProps = {
   tasksDue?: number
   note?: string
   hydrationHistory?: number[]
+  photo?: string
 }
 
 export function getHydrationProgress(hydration: number) {
@@ -28,9 +29,22 @@ export default function PlantCard({
   tasksDue = 0,
   note,
   hydrationHistory,
+  photo,
 }: PlantCardProps) {
   const { pct, barColor } = getHydrationProgress(hydration)
   const badgeColor = tasksDue > 0 ? 'bg-red-500 text-white' : 'bg-flora-leaf text-white'
+  const statusColor =
+    status === 'Water overdue'
+      ? 'bg-red-500 text-white'
+      : status === 'Due today'
+      ? 'bg-yellow-500 text-gray-900'
+      : status === 'Fertilize suggested'
+      ? 'bg-green-500 text-white'
+      : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+
+  const history = hydrationHistory ?? []
+  const padded = Array.from({ length: 7 }, (_, i) => history[history.length - 7 + i] ?? 0)
+  const wateringStreak = padded.map((val, i) => (i > 0 ? val > padded[i - 1] : false))
 
   return (
     <motion.div
@@ -43,10 +57,20 @@ export default function PlantCard({
       whileTap={tap}
       transition={defaultTransition}
     >
-      <h3 className="font-semibold text-gray-900 dark:text-gray-100">
-        {nickname} <span className="italic text-gray-500 dark:text-gray-400">— {species}</span>
-      </h3>
-      <p className="text-sm text-gray-700 dark:text-gray-300">{status}</p>
+      {photo && (
+        <img
+          src={photo}
+          alt={nickname}
+          className="w-full h-32 object-cover rounded-md mb-2"
+        />
+      )}
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="font-bold text-gray-900 dark:text-gray-100">{nickname}</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{species}</p>
+        </div>
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusColor}`}>{status}</span>
+      </div>
       {note && <p className="text-xs text-gray-600 dark:text-gray-400">{note}</p>}
       <div
         className="w-full bg-gray-200 rounded-full h-2 mt-2"
@@ -61,9 +85,17 @@ export default function PlantCard({
         />
       </div>
       <div className="flex items-center justify-between mt-2">
-        <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
-          Hydration: {pct}%
+        <div className="text-xs text-gray-500 dark:text-gray-400 flex flex-col gap-1">
           {hydrationHistory && <Sparkline data={hydrationHistory} />}
+          <div className="flex gap-1">
+            {wateringStreak.map((w, i) => (
+              <span
+                key={i}
+                data-testid="water-dot"
+                className={`w-2 h-2 rounded-full ${w ? 'bg-flora-leaf' : 'bg-gray-300 dark:bg-gray-700'}`}
+              />
+            ))}
+          </div>
         </div>
         <div className="flex items-center gap-1">
           <span className="text-xs text-gray-500 dark:text-gray-400">Tasks</span>

--- a/components/__tests__/PlantCard.test.tsx
+++ b/components/__tests__/PlantCard.test.tsx
@@ -2,15 +2,17 @@ import { render, screen } from '@testing-library/react'
 import PlantCard from '../PlantCard'
 
 describe('PlantCard', () => {
-  it('renders plant details with hydration progress and tasks badge', () => {
+  it('renders plant details with sparkline and care streak', () => {
     render(
       <PlantCard
         nickname="Fern"
         species="Pteridophyta"
-        status="Healthy"
+        status="Water overdue"
         hydration={55.4}
         tasksDue={3}
         note="Needs sun"
+        photo="https://example.com/fern.jpg"
+        hydrationHistory={[40, 45, 50, 55, 53, 60, 55]}
       />
     )
 
@@ -19,11 +21,12 @@ describe('PlantCard', () => {
     expect(progress).toHaveAttribute('aria-valuemin', '0')
     expect(progress).toHaveAttribute('aria-valuemax', '100')
 
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/fern.jpg')
     expect(screen.getByText(/fern/i)).toBeInTheDocument()
     expect(screen.getByText(/pteridophyta/i)).toBeInTheDocument()
-    expect(screen.getByText(/healthy/i)).toBeInTheDocument()
+    expect(screen.getByText(/water overdue/i)).toBeInTheDocument()
     expect(screen.getByText(/needs sun/i)).toBeInTheDocument()
-    expect(screen.getByText(/Hydration: 55%/i)).toBeInTheDocument()
+    expect(screen.getAllByTestId('water-dot')).toHaveLength(7)
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- show plant thumbnails and color-coded status pills
- swap hydration text for sparkline and care streak dots
- apply bolder nickname typography with lighter species

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4eb2f178483248f30122c31d189c6