### PR TITLE
feat: add insights and lab mode

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -6,7 +6,8 @@ import PlantCard from "@/components/PlantCard"
 import Footer from "@/components/Footer"
 import Header from "@/components/Header"
 import { samplePlants } from "@/lib/plants"
-import { parse, format, subDays } from "date-fns"
+import { downloadCsv } from "@/lib/utils"
+import { parse, format, subDays, differenceInDays, addDays, isSameDay } from "date-fns"
 
 type GroupBy = "status" | "room" | "none"
 type SortBy = "hydration" | "alpha" | "lastWatered"
@@ -14,6 +15,7 @@ type SortBy = "hydration" | "alpha" | "lastWatered"
 export default function TodayPage() {
   const [groupBy, setGroupBy] = useState<GroupBy>("none")
   const [sortBy, setSortBy] = useState<SortBy>("alpha")
+  const [labMode, setLabMode] = useState(false)
 
   const plants = Object.entries(samplePlants)
   const plantsCount = plants.length
@@ -30,8 +32,53 @@ export default function TodayPage() {
   const waterOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("water overdue"))
   const fertilizeOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("fertilize overdue"))
   const noteOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("note overdue"))
-
-  const eventDates = plants.flatMap(([, p]) =>
+  const overduePercent = Math.round(
+    (plants.filter(([, p]) => p.status.toLowerCase().includes("overdue")).length / plantsCount) * 100
+  )
+  const avgWateringInterval = Math.round(
+    plants.reduce((sum, [, p]) => {
+      return sum + differenceInDays(new Date(), parse(`${p.lastWatered} 2024`, "MMM d yyyy", new Date()))
+    }, 0) / plantsCount
+  )
+  const plantStreaks = plants.map(([, p]) => {
+    const dates = p.events.map((e) => parse(`${e.date} 2024`, "MMM d yyyy", new Date()))
+    const set = new Set(dates.map((d) => format(d, "yyyy-MM-dd")))
+    let streak = 0
+    if (set.size > 0) {
+      let current = dates.reduce((a, b) => (a > b ? a : b))
+      while (set.has(format(current, "yyyy-MM-dd"))) {
+        streak++
+        current = subDays(current, 1)
+      }
+    }
+    return { plant: p.nickname, streak }
+  })
+  const longestStreakPlant = plantStreaks.reduce((max, p) => (p.streak > max.streak ? p : max), { plant: "", streak: 0 }).plant
+  const tomorrow = addDays(new Date(), 1)
+  const nextDayTasks = plants.filter(([, p]) =>
+    isSameDay(parse(`${p.nextDue} 2024`, "MMM d yyyy", new Date()), tomorrow)
+  )
+  const nextDayWaterTasks = nextDayTasks.filter(([, p]) => {
+    const s = p.status.toLowerCase()
+    return s.includes("water") || (!s.includes("fertilize") && !s.includes("note"))
+  }).length
+  const nextDayFertilizeTasks = nextDayTasks.filter(([, p]) => p.status.toLowerCase().includes("fertilize")).length
+  const nextDayNoteTasks = nextDayTasks.filter(([, p]) => p.status.toLowerCase().includes("note")).length
+  const todayTasksData = plants.flatMap(([, p]) => {
+    const s = p.status.toLowerCase()
+    const tasks: { plant: string; task: string; status: string }[] = []
+    if (s.includes("water overdue") || (s.includes("due") && !s.includes("fertilize"))) {
+      tasks.push({ plant: p.nickname, task: "Water", status: p.status })
+    }
+    if (s.includes("fertilize")) {
+      tasks.push({ plant: p.nickname, task: "Fertilize", status: p.status })
+    }
+    if (s.includes("note")) {
+      tasks.push({ plant: p.nickname, task: "Note", status: p.status })
+    }
+    return tasks
+  })
+    const eventDates = plants.flatMap(([, p]) =>
     p.events.map((e) => parse(`${e.date} 2024`, "MMM d yyyy", new Date()))
   )
   const dateSet = new Set(eventDates.map((d) => format(d, "yyyy-MM-dd")))
@@ -97,7 +144,7 @@ export default function TodayPage() {
             </p>
           </header>
 
-          <div className="flex gap-4 mb-4">
+          <div className="flex gap-4 mb-4 items-center">
             <select
               value={groupBy}
               onChange={(e) => setGroupBy(e.target.value as GroupBy)}
@@ -116,6 +163,14 @@ export default function TodayPage() {
               <option value="hydration">Hydration</option>
               <option value="lastWatered">Last watered</option>
             </select>
+            <label className="flex items-center gap-1 text-sm">
+              <input
+                type="checkbox"
+                checked={labMode}
+                onChange={(e) => setLabMode(e.target.checked)}
+              />
+              Lab mode
+            </label>
           </div>
 
           {groupBy === "none" ? (
@@ -183,6 +238,51 @@ export default function TodayPage() {
                   </details>
                 ))}
             </div>
+          )}
+
+
+          <section className="mt-8">
+            <h3 className="text-lg font-semibold mb-2">Insights</h3>
+            <ul className="list-disc pl-5 text-sm">
+              <li>{overduePercent}% of plants are overdue</li>
+              <li>Avg watering interval {avgWateringInterval} days</li>
+              <li>Longest on-time streak: {longestStreakPlant || "N/A"}</li>
+              <li>
+                Tasks due tomorrow: {nextDayWaterTasks} water, {nextDayFertilizeTasks} fertilize, {nextDayNoteTasks} notes
+              </li>
+            </ul>
+          </section>
+
+          {labMode && (
+            <section className="mt-8">
+              <h3 className="text-lg font-semibold mb-2">Lab data</h3>
+              <button
+                onClick={() => downloadCsv("today-tasks.csv", todayTasksData)}
+                className="mb-2 px-3 py-1 border rounded"
+              >
+                Export CSV
+              </button>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr>
+                      <th className="text-left p-2">Plant</th>
+                      <th className="text-left p-2">Task</th>
+                      <th className="text-left p-2">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {todayTasksData.map((t, i) => (
+                      <tr key={i} className="border-t">
+                        <td className="p-2">{t.plant}</td>
+                        <td className="p-2">{t.task}</td>
+                        <td className="p-2">{t.status}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
           )}
 
           <Footer />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,3 +23,23 @@ export function formatVpd(vpd: number, unit = 'kPa'): string {
 }
 
 // TODO: Wire to real sync events once data persistence is available.
+export function toCsv(rows: Record<string, any>[]): string {
+  if (!rows.length) return ''
+  const headers = Object.keys(rows[0])
+  const lines = [headers.join(',')]
+  for (const row of rows) {
+    lines.push(headers.map((h) => JSON.stringify(row[h] ?? '')).join(','))
+  }
+  return lines.join('\n')
+}
+
+export function downloadCsv(filename: string, rows: Record<string, any>[]): void {
+  const csv = toCsv(rows)
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const link = document.createElement('a')
+  const url = URL.createObjectURL(blob)
+  link.setAttribute('href', url)
+  link.setAttribute('download', filename)
+  link.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- compute overdue percentages, watering intervals, plant streaks, and next-day task counts
- show an Insights section with these metrics
- add Lab mode for task data table with CSV export

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f197bae88324be4be02c5bc15b79