### PR TITLE
refactor plant detail into components

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -1,80 +1,29 @@
 'use client'
 
-import Image from "next/image"
 import { useEffect, useState, useCallback } from "react"
-import Lightbox from "@/components/Lightbox"
-import Sparkline from "@/components/Sparkline"
-import { Droplet, Sprout, FileText, Calendar, Activity } from "lucide-react"
-import { getHydrationProgress } from "@/components/PlantCard"
+import { ToastProvider, useToast } from "@/components/Toast"
 import PlantDetailSkeleton from "./PlantDetailSkeleton"
 import WaterModal from "@/components/WaterModal"
 import FertilizeModal from "@/components/FertilizeModal"
 import NoteModal from "@/components/NoteModal"
-import { ToastProvider, useToast } from "@/components/Toast"
-import {
-  CareTrendsChart,
-  HydrationTrendChart,
-  NutrientLevelChart,
-  StressIndexGauge,
-  PlantHealthRadar,
-} from "@/components/Charts"
-import { calculateNutrientAvailability, calculateStressIndex } from "@/lib/plant-metrics"
-
+import HeroSection from "@/components/plant-detail/HeroSection"
+import QuickStats from "@/components/plant-detail/QuickStats"
+import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
+import CareTrends from "@/components/plant-detail/CareTrends"
+import Timeline from "@/components/plant-detail/Timeline"
+import Gallery from "@/components/plant-detail/Gallery"
+import type { Plant, PlantEvent } from "@/components/plant-detail/types"
 import { getWeatherForUser, type Weather } from "@/lib/weather"
 import { samplePlants } from "@/lib/plants"
 
-
-interface PlantEvent {
-  id: number
-  type: string
-  date: string
-  note?: string
-}
-
-interface Plant {
-  nickname: string
-  species: string
-  status: string
-  hydration: number
-  hydrationLog?: { date: string; value: number }[]
-  lastWatered: string
-  nextDue: string
-  lastFertilized: string
-  nutrientLevel?: number
-  events: PlantEvent[]
-  photos: string[]
-}
-
-const EVENT_TYPES = {
-  water: {
-    label: "Watered",
-    color: "bg-blue-100 text-blue-700",
-    icon: Droplet,
-  },
-  fertilize: {
-    label: "Fertilized",
-    color: "bg-green-100 text-green-700",
-    icon: Sprout,
-  },
-  note: {
-    label: "Note",
-    color: "bg-purple-100 text-purple-700",
-    icon: FileText,
-  },
-} as const
 
 export function PlantDetailContent({ params }: { params: { id: string } }) {
   const [plant, setPlant] = useState<Plant | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const progress = getHydrationProgress(plant?.hydration ?? 0)
   const [waterOpen, setWaterOpen] = useState(false)
   const [fertilizeOpen, setFertilizeOpen] = useState(false)
   const [noteOpen, setNoteOpen] = useState(false)
-  const [trendView, setTrendView] = useState<"monthly" | "weekly" | "yearly">(
-    "monthly",
-  )
-  const [expandedId, setExpandedId] = useState<number | null>(null)
   const toast = useToast()
   const [weather, setWeather] = useState<Weather | null>(null)
   const [offline, setOffline] = useState(false)
@@ -93,14 +42,6 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
       }
     }
     date.setDate(date.getDate() + days)
-    return date.toLocaleDateString(undefined, { month: "short", day: "numeric" })
-  }
-
-  function calculateNextFeedDate(lastFertilized: string, nutrientLevel: number) {
-    const current = calculateNutrientAvailability(lastFertilized, nutrientLevel)
-    const daysLeft = Math.max(0, Math.ceil((current - 30) / 2))
-    const date = new Date()
-    date.setDate(date.getDate() + daysLeft)
     return date.toLocaleDateString(undefined, { month: "short", day: "numeric" })
   }
 
@@ -282,243 +223,17 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
         ) : (
           <>
 
-            {/* Hero Section */}
-            <section className="space-y-4">
-              <div className="relative rounded-xl overflow-hidden shadow">
-                {plant.photos && plant.photos.length > 0 ? (
-                  <Image
-                    src={plant.photos[0]}
-                    alt={plant.nickname}
-                    width={1200}
-                    height={800}
-                    sizes="100vw"
-                    className="w-full h-64 sm:h-80 object-cover"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="w-full h-64 sm:h-80 flex items-center justify-center bg-gray-100 dark:bg-gray-800">
-                    <span className="text-gray-500 dark:text-gray-400">No photo</span>
-                  </div>
-                )}
-                <div className="absolute inset-0 bg-black/30 flex flex-col justify-end p-4 sm:p-6">
-                  <h1 className="text-3xl font-bold text-white drop-shadow-md">
-                    {plant.nickname}
-                  </h1>
-                  <p className="italic text-gray-200">{plant.species}</p>
-                </div>
-              </div>
-
-              <div className="flex flex-wrap justify-center sm:justify-start gap-3">
-                <button
-                  onClick={handleWater}
-                  aria-label="Water plant"
-                  className="flex items-center gap-1 px-4 py-2 rounded-full bg-blue-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600"
-                >
-                  <Droplet className="h-4 w-4" />
-                  Water
-                </button>
-                <button
-                  onClick={handleFertilize}
-                  aria-label="Fertilize plant"
-                  className="flex items-center gap-1 px-4 py-2 rounded-full bg-green-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:bg-green-500 dark:hover:bg-green-600"
-                >
-                  <Sprout className="h-4 w-4" />
-                  Fertilize
-                </button>
-                <button
-                  onClick={handleAddNote}
-                  aria-label="Add note to plant"
-                  className="flex items-center gap-1 px-4 py-2 rounded-full bg-purple-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:bg-purple-500 dark:hover:bg-purple-600"
-                >
-                  <FileText className="h-4 w-4" />
-                  Add Note
-                </button>
-              </div>
-              <div className="flex flex-wrap justify-center sm:justify-start gap-2 text-sm">
-                <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">
-                  {plant.status}
-                </span>
-              </div>
-              <div
-                className="w-full bg-gray-200 rounded-full h-2"
-                role="progressbar"
-                aria-label="Hydration"
-                aria-valuenow={progress.pct}
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuetext={`${progress.pct}% hydration`}
-              >
-                <div
-                  className={`h-2 rounded-full ${progress.barColor}`}
-                  style={{ width: `${progress.pct}%` }}
-                />
-                <span className="sr-only">{`${progress.pct}% hydration`}</span>
-              </div>
-            </section>
-
-            {/* Quick Stats */}
-            <section className="grid grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
-              {[
-                { label: "Last Watered", value: plant.lastWatered, icon: Droplet },
-                { label: "Next Water Due", value: plant.nextDue, icon: Calendar },
-                { label: "Last Fertilized", value: plant.lastFertilized, icon: Sprout },
-                {
-                  label: "Next Feed",
-                  value: calculateNextFeedDate(
-                    plant.lastFertilized,
-                    plant.nutrientLevel ?? 100,
-                  ),
-                  icon: Calendar,
-                },
-                {
-                  label: "Hydration",
-                  value: `${plant.hydration}%`,
-                  icon: Droplet,
-                  spark: plant.hydrationLog?.map((h) => h.value) ?? [],
-                },
-                {
-                  label: "Stress Score",
-                  value: Math.round(
-                    calculateStressIndex({
-                      overdueDays: plant.status === "Water overdue" ? 1 : 0,
-                      hydration: plant.hydration,
-                      temperature: weather?.temperature ?? 25,
-                      light: 50,
-                    }),
-                  ),
-                  icon: Activity,
-                  color: "text-orange-600",
-                },
-              ].map(({ label, value, icon: Icon, spark, color }) => (
-                <div
-                  key={label}
-                  className="flex flex-col items-center justify-center gap-1 rounded-lg border p-4 bg-white shadow-sm dark:bg-gray-900 dark:border-gray-700"
-                >
-                  <Icon className={`h-5 w-5 text-gray-500 dark:text-gray-400 ${color ?? ""}`} />
-                  <span className="text-xl font-bold text-gray-900 dark:text-white">
-                    {value}
-                  </span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
-                  {spark && spark.length > 1 && <Sparkline data={spark} />}
-                </div>
-              ))}
-            </section>
-
-            {/* Analytics Panel */}
-            <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-6">
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <StressIndexGauge
-                  value={calculateStressIndex({
-                    overdueDays: plant.status === "Water overdue" ? 1 : 0,
-                    hydration: plant.hydration,
-                    temperature: weather?.temperature ?? 25,
-                    light: 50,
-                  })}
-                />
-                <PlantHealthRadar
-                  hydration={plant.hydration}
-                  lastFertilized={plant.lastFertilized}
-                  nutrientLevel={plant.nutrientLevel ?? 100}
-                  events={plant.events}
-                  status={plant.status}
-                  weather={weather}
-                />
-              </div>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <NutrientLevelChart
-                  lastFertilized={plant.lastFertilized}
-                  nutrientLevel={plant.nutrientLevel ?? 100}
-                />
-                <HydrationTrendChart log={plant.hydrationLog ?? []} />
-              </div>
-            </section>
-
-            {/* Care Trends */}
-            <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold">Care Trends</h2>
-                <div className="flex gap-2 text-sm">
-                  {(["monthly", "weekly", "yearly"] as const).map((v) => (
-                    <button
-                      key={v}
-                      onClick={() => setTrendView(v)}
-                      className={`px-3 py-1 rounded-full capitalize transition-colors ${
-                        trendView === v
-                          ? "bg-blue-600 text-white"
-                          : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-                      }`}
-                    >
-                      {v}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <p className="text-sm text-gray-500 mb-2">
-                100% tasks completed on time this month
-              </p>
-              <CareTrendsChart events={plant.events} view={trendView} />
-            </section>
-
-            {/* Timeline */}
-            <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-4">
-              <h2 className="text-lg font-semibold">Timeline</h2>
-              {!plant.events || plant.events.length === 0 ? (
-                <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
-              ) : (
-                <ol className="relative border-l ml-4">
-                  {plant.events
-                    .filter((e): e is PlantEvent => e !== null && e !== undefined)
-                    .map((e) => {
-                      const type =
-                        EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
-                      const Icon = type.icon
-                      const dot =
-                        e.type === "water"
-                          ? "bg-blue-500"
-                          : e.type === "fertilize"
-                          ? "bg-green-500"
-                          : "bg-purple-500"
-                      const open = expandedId === e.id
-                      return (
-                        <li key={e.id} className="mb-6 ml-6">
-                          <span
-                            className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full text-white ${dot} ring-2 ring-white transition-transform hover:scale-110`}
-                          >
-                            <Icon className="w-3 h-3" />
-                          </span>
-                          <button
-                            onClick={() => setExpandedId(open ? null : e.id)}
-                            className="text-left w-full"
-                          >
-                            <time className="block text-xs text-gray-500">{e.date}</time>
-                            <span className="font-medium">{type.label}</span>
-                          </button>
-                          {open && (
-                            <div className="mt-2 p-3 rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-700 text-sm">
-                              {e.type === "note" && e.note}
-                            </div>
-                          )}
-                        </li>
-                      )
-                    })}
-                </ol>
-              )}
-            </section>
-
-            {/* Gallery */}
-            <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
-              <h2 className="text-lg font-semibold mb-4">Gallery</h2>
-              {plant.photos && plant.photos.length > 0 ? (
-                <Lightbox
-                  images={plant.photos.map((src, i) => ({
-                    src,
-                    alt: `${plant.nickname} photo ${i + 1}`,
-                  }))}
-                />
-              ) : (
-                <p className="text-sm text-gray-500 dark:text-gray-400">No photos available.</p>
-              )}
-            </section>
+            <HeroSection
+              plant={plant}
+              onWater={handleWater}
+              onFertilize={handleFertilize}
+              onAddNote={handleAddNote}
+            />
+            <QuickStats plant={plant} weather={weather} />
+            <AnalyticsPanel plant={plant} weather={weather} />
+            <CareTrends events={plant.events} />
+            <Timeline events={plant.events} />
+            <Gallery photos={plant.photos} nickname={plant.nickname} />
           </>
         )}
       </div>

--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { StressIndexGauge, PlantHealthRadar, NutrientLevelChart, HydrationTrendChart } from '@/components/Charts'
+import { calculateStressIndex } from '@/lib/plant-metrics'
+import type { Plant } from './types'
+import type { Weather } from '@/lib/weather'
+
+interface AnalyticsPanelProps {
+  plant: Plant
+  weather: Weather | null
+}
+
+export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) {
+  return (
+    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <StressIndexGauge
+          value={calculateStressIndex({
+            overdueDays: plant.status === 'Water overdue' ? 1 : 0,
+            hydration: plant.hydration,
+            temperature: weather?.temperature ?? 25,
+            light: 50,
+          })}
+        />
+        <PlantHealthRadar
+          hydration={plant.hydration}
+          lastFertilized={plant.lastFertilized}
+          nutrientLevel={plant.nutrientLevel ?? 100}
+          events={plant.events}
+          status={plant.status}
+          weather={weather}
+        />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <NutrientLevelChart
+          lastFertilized={plant.lastFertilized}
+          nutrientLevel={plant.nutrientLevel ?? 100}
+        />
+        <HydrationTrendChart log={plant.hydrationLog ?? []} />
+      </div>
+    </section>
+  )
+}

--- a/components/plant-detail/CareTrends.tsx
+++ b/components/plant-detail/CareTrends.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+import { CareTrendsChart } from '@/components/Charts'
+import type { PlantEvent } from './types'
+
+interface CareTrendsProps {
+  events: PlantEvent[]
+}
+
+export default function CareTrends({ events }: CareTrendsProps) {
+  const [view, setView] = useState<'monthly' | 'weekly' | 'yearly'>('monthly')
+
+  return (
+    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">Care Trends</h2>
+        <div className="flex gap-2 text-sm">
+          {(['monthly', 'weekly', 'yearly'] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-3 py-1 rounded-full capitalize transition-colors ${
+                view === v
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
+              }`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="text-sm text-gray-500 mb-2">
+        100% tasks completed on time this month
+      </p>
+      <CareTrendsChart events={events} view={view} />
+    </section>
+  )
+}

--- a/components/plant-detail/Gallery.tsx
+++ b/components/plant-detail/Gallery.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import Lightbox from '@/components/Lightbox'
+
+interface GalleryProps {
+  photos: string[]
+  nickname: string
+}
+
+export default function Gallery({ photos, nickname }: GalleryProps) {
+  return (
+    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
+      <h2 className="text-lg font-semibold mb-4">Gallery</h2>
+      {photos && photos.length > 0 ? (
+        <Lightbox
+          images={photos.map((src, i) => ({ src, alt: `${nickname} photo ${i + 1}` }))}
+        />
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">No photos available.</p>
+      )}
+    </section>
+  )
+}

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Image from 'next/image'
+import { Droplet, Sprout, FileText } from 'lucide-react'
+import { getHydrationProgress } from '@/components/PlantCard'
+import type { Plant } from './types'
+
+interface HeroSectionProps {
+  plant: Plant
+  onWater: () => void
+  onFertilize: () => void
+  onAddNote: () => void
+}
+
+export default function HeroSection({
+  plant,
+  onWater,
+  onFertilize,
+  onAddNote,
+}: HeroSectionProps) {
+  const progress = getHydrationProgress(plant.hydration)
+
+  return (
+    <section className="space-y-4">
+      <div className="relative rounded-xl overflow-hidden shadow">
+        {plant.photos && plant.photos.length > 0 ? (
+          <Image
+            src={plant.photos[0]}
+            alt={plant.nickname}
+            width={1200}
+            height={800}
+            sizes="100vw"
+            className="w-full h-64 sm:h-80 object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-64 sm:h-80 flex items-center justify-center bg-gray-100 dark:bg-gray-800">
+            <span className="text-gray-500 dark:text-gray-400">No photo</span>
+          </div>
+        )}
+        <div className="absolute inset-0 bg-black/30 flex flex-col justify-end p-4 sm:p-6">
+          <h1 className="text-3xl font-bold text-white drop-shadow-md">
+            {plant.nickname}
+          </h1>
+          <p className="italic text-gray-200">{plant.species}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap justify-center sm:justify-start gap-3">
+        <button
+          onClick={onWater}
+          aria-label="Water plant"
+          className="flex items-center gap-1 px-4 py-2 rounded-full bg-blue-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600"
+        >
+          <Droplet className="h-4 w-4" />
+          Water
+        </button>
+        <button
+          onClick={onFertilize}
+          aria-label="Fertilize plant"
+          className="flex items-center gap-1 px-4 py-2 rounded-full bg-green-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:bg-green-500 dark:hover:bg-green-600"
+        >
+          <Sprout className="h-4 w-4" />
+          Fertilize
+        </button>
+        <button
+          onClick={onAddNote}
+          aria-label="Add note to plant"
+          className="flex items-center gap-1 px-4 py-2 rounded-full bg-purple-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:bg-purple-500 dark:hover:bg-purple-600"
+        >
+          <FileText className="h-4 w-4" />
+          Add Note
+        </button>
+      </div>
+      <div className="flex flex-wrap justify-center sm:justify-start gap-2 text-sm">
+        <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">
+          {plant.status}
+        </span>
+      </div>
+      <div
+        className="w-full bg-gray-200 rounded-full h-2"
+        role="progressbar"
+        aria-label="Hydration"
+        aria-valuenow={progress.pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuetext={`${progress.pct}% hydration`}
+      >
+        <div
+          className={`h-2 rounded-full ${progress.barColor}`}
+          style={{ width: `${progress.pct}%` }}
+        />
+        <span className="sr-only">{`${progress.pct}% hydration`}</span>
+      </div>
+    </section>
+  )
+}

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import Sparkline from '@/components/Sparkline'
+import { Droplet, Sprout, Calendar, Activity } from 'lucide-react'
+import { calculateNutrientAvailability, calculateStressIndex } from '@/lib/plant-metrics'
+import type { Plant } from './types'
+import type { Weather } from '@/lib/weather'
+
+interface QuickStatsProps {
+  plant: Plant
+  weather: Weather | null
+}
+
+function calculateNextFeedDate(lastFertilized: string, nutrientLevel: number) {
+  const current = calculateNutrientAvailability(lastFertilized, nutrientLevel)
+  const daysLeft = Math.max(0, Math.ceil((current - 30) / 2))
+  const date = new Date()
+  date.setDate(date.getDate() + daysLeft)
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+export default function QuickStats({ plant, weather }: QuickStatsProps) {
+  return (
+    <section className="grid grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+      {[
+        { label: 'Last Watered', value: plant.lastWatered, icon: Droplet },
+        { label: 'Next Water Due', value: plant.nextDue, icon: Calendar },
+        { label: 'Last Fertilized', value: plant.lastFertilized, icon: Sprout },
+        {
+          label: 'Next Feed',
+          value: calculateNextFeedDate(
+            plant.lastFertilized,
+            plant.nutrientLevel ?? 100
+          ),
+          icon: Calendar,
+        },
+        {
+          label: 'Hydration',
+          value: `${plant.hydration}%`,
+          icon: Droplet,
+          spark: plant.hydrationLog?.map((h) => h.value) ?? [],
+        },
+        {
+          label: 'Stress Score',
+          value: Math.round(
+            calculateStressIndex({
+              overdueDays: plant.status === 'Water overdue' ? 1 : 0,
+              hydration: plant.hydration,
+              temperature: weather?.temperature ?? 25,
+              light: 50,
+            })
+          ),
+          icon: Activity,
+          color: 'text-orange-600',
+        },
+      ].map(({ label, value, icon: Icon, spark, color }) => (
+        <div
+          key={label}
+          className="flex flex-col items-center justify-center gap-1 rounded-lg border p-4 bg-white shadow-sm dark:bg-gray-900 dark:border-gray-700"
+        >
+          <Icon className={`h-5 w-5 text-gray-500 dark:text-gray-400 ${color ?? ''}`} />
+          <span className="text-xl font-bold text-gray-900 dark:text-white">
+            {value}
+          </span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
+          {spark && spark.length > 1 && <Sparkline data={spark} />}
+        </div>
+      ))}
+    </section>
+  )
+}

--- a/components/plant-detail/Timeline.tsx
+++ b/components/plant-detail/Timeline.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState } from 'react'
+import { Droplet, Sprout, FileText } from 'lucide-react'
+import type { PlantEvent } from './types'
+
+const EVENT_TYPES = {
+  water: {
+    label: 'Watered',
+    color: 'bg-blue-100 text-blue-700',
+    icon: Droplet,
+  },
+  fertilize: {
+    label: 'Fertilized',
+    color: 'bg-green-100 text-green-700',
+    icon: Sprout,
+  },
+  note: {
+    label: 'Note',
+    color: 'bg-purple-100 text-purple-700',
+    icon: FileText,
+  },
+} as const
+
+export default function Timeline({ events }: { events: PlantEvent[] }) {
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  return (
+    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-4">
+      <h2 className="text-lg font-semibold">Timeline</h2>
+      {!events || events.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
+      ) : (
+        <ol className="relative border-l ml-4">
+          {events
+            .filter((e): e is PlantEvent => e !== null && e !== undefined)
+            .map((e) => {
+              const type =
+                EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
+              const Icon = type.icon
+              const dot =
+                e.type === 'water'
+                  ? 'bg-blue-500'
+                  : e.type === 'fertilize'
+                  ? 'bg-green-500'
+                  : 'bg-purple-500'
+              const open = expandedId === e.id
+              return (
+                <li key={e.id} className="mb-6 ml-6">
+                  <span
+                    className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full text-white ${dot} ring-2 ring-white transition-transform hover:scale-110`}
+                  >
+                    <Icon className="w-3 h-3" />
+                  </span>
+                  <button
+                    onClick={() => setExpandedId(open ? null : e.id)}
+                    className="text-left w-full"
+                  >
+                    <time className="block text-xs text-gray-500">{e.date}</time>
+                    <span className="font-medium">{type.label}</span>
+                  </button>
+                  {open && (
+                    <div className="mt-2 p-3 rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-700 text-sm">
+                      {e.type === 'note' && e.note}
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+        </ol>
+      )}
+    </section>
+  )
+}

--- a/components/plant-detail/types.ts
+++ b/components/plant-detail/types.ts
@@ -1,0 +1,20 @@
+export interface PlantEvent {
+  id: number
+  type: string
+  date: string
+  note?: string
+}
+
+export interface Plant {
+  nickname: string
+  species: string
+  status: string
+  hydration: number
+  hydrationLog?: { date: string; value: number }[]
+  lastWatered: string
+  nextDue: string
+  lastFertilized: string
+  nutrientLevel?: number
+  events: PlantEvent[]
+  photos: string[]
+}


### PR DESCRIPTION
## Summary
- break plant detail page into modular components
- add dedicated plant detail sections for hero, stats, analytics, care trends, timeline, and gallery

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f455da688324ae357bf21ec233e7