### PR TITLE
Refactor dashboard into modular components and hooks

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,103 +1,58 @@
 "use client"
 
-import Link from "next/link"
-import { useState } from "react"
-import PlantCard from "@/components/PlantCard"
+import { useState, useMemo } from "react"
+import { parse } from "date-fns"
 import Footer from "@/components/Footer"
 import Header from "@/components/Header"
+import ControlsBar from "@/components/ControlsBar"
+import PlantList from "@/components/PlantList"
+import InsightsBlock from "@/components/InsightsBlock"
 import { samplePlants } from "@/lib/plants"
-import { parse, format, subDays, differenceInDays, addDays, isSameDay } from "date-fns"
-
-type GroupBy = "status" | "room" | "none"
-type SortBy = "hydration" | "alpha" | "lastWatered"
+import { GroupBy, SortBy } from "@/lib/dashboardTypes"
+import usePlantMetrics from "@/hooks/usePlantMetrics"
 
 export default function TodayPage() {
   const [groupBy, setGroupBy] = useState<GroupBy>("none")
   const [sortBy, setSortBy] = useState<SortBy>("alpha")
 
-  const plants = Object.entries(samplePlants)
-  const plantsCount = plants.length
-  const avgHydration = Math.round(
-    plants.reduce((sum, [, p]) => sum + p.hydration, 0) / plantsCount
-  )
-  const tasksDue = plants.filter(([, p]) => p.status.toLowerCase().includes("due")).length
-  const waterTasks = plants.filter(([, p]) => {
-    const s = p.status.toLowerCase()
-    return s.includes("water overdue") || (s.includes("due") && !s.includes("fertilize"))
-  }).length
-  const fertilizeTasks = plants.filter(([, p]) => p.status.toLowerCase().includes("fertilize")).length
-  const noteTasks = plants.filter(([, p]) => p.status.toLowerCase().includes("note")).length
-  const waterOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("water overdue"))
-  const fertilizeOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("fertilize overdue"))
-  const noteOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("note overdue"))
-  const overduePercent = Math.round(
-    (plants.filter(([, p]) => p.status.toLowerCase().includes("overdue")).length / plantsCount) * 100
-  )
-  const avgWateringInterval = Math.round(
-    plants.reduce((sum, [, p]) => {
-      return sum + differenceInDays(new Date(), parse(`${p.lastWatered} 2024`, "MMM d yyyy", new Date()))
-    }, 0) / plantsCount
-  )
-  const plantStreaks = plants.map(([, p]) => {
-    const dates = p.events.map((e) => parse(`${e.date} 2024`, "MMM d yyyy", new Date()))
-    const set = new Set(dates.map((d) => format(d, "yyyy-MM-dd")))
-    let streak = 0
-    if (set.size > 0) {
-      let current = dates.reduce((a, b) => (a > b ? a : b))
-      while (set.has(format(current, "yyyy-MM-dd"))) {
-        streak++
-        current = subDays(current, 1)
-      }
-    }
-    return { plant: p.nickname, streak }
-  })
-  const longestStreakPlant = plantStreaks.reduce((max, p) => (p.streak > max.streak ? p : max), { plant: "", streak: 0 }).plant
-  const tomorrow = addDays(new Date(), 1)
-  const nextDayTasks = plants.filter(([, p]) =>
-    isSameDay(parse(`${p.nextDue} 2024`, "MMM d yyyy", new Date()), tomorrow)
-  )
-  const nextDayWaterTasks = nextDayTasks.filter(([, p]) => {
-    const s = p.status.toLowerCase()
-    return s.includes("water") || (!s.includes("fertilize") && !s.includes("note"))
-  }).length
-  const nextDayFertilizeTasks = nextDayTasks.filter(([, p]) => p.status.toLowerCase().includes("fertilize")).length
-  const nextDayNoteTasks = nextDayTasks.filter(([, p]) => p.status.toLowerCase().includes("note")).length
-  const eventDates = plants.flatMap(([, p]) =>
-    p.events.map((e) => parse(`${e.date} 2024`, "MMM d yyyy", new Date()))
-  )
-  const dateSet = new Set(eventDates.map((d) => format(d, "yyyy-MM-dd")))
-  let taskStreak = 0
-  if (dateSet.size > 0) {
-    let current = eventDates.reduce((a, b) => (a > b ? a : b))
-    while (dateSet.has(format(current, "yyyy-MM-dd"))) {
-      taskStreak++
-      current = subDays(current, 1)
-    }
-  }
+  const plants = useMemo(() => Object.entries(samplePlants), [])
+  const {
+    plantsCount,
+    avgHydration,
+    tasksDue,
+    waterTasks,
+    fertilizeTasks,
+    noteTasks,
+    waterOverdue,
+    fertilizeOverdue,
+    noteOverdue,
+    overduePercent,
+    avgWateringInterval,
+    longestStreakPlant,
+    taskStreak,
+    nextDayWaterTasks,
+    nextDayFertilizeTasks,
+    nextDayNoteTasks,
+  } = usePlantMetrics(plants)
   const avgHydrationHistory = [65, 70, 68, 72, 75]
 
-  const sortedPlants = [...plants].sort((a, b) => {
-    const [, pa] = a
-    const [, pb] = b
-    switch (sortBy) {
-      case "hydration":
-        return pb.hydration - pa.hydration
-      case "lastWatered":
-        return (
-          parse(`${pb.lastWatered} 2024`, "MMM d yyyy", new Date()).getTime() -
-          parse(`${pa.lastWatered} 2024`, "MMM d yyyy", new Date()).getTime()
-        )
-      default:
-        return pa.nickname.localeCompare(pb.nickname)
-    }
-  })
-
-  const grouped = groupBy === "none" ? { All: sortedPlants } : sortedPlants.reduce<Record<string, typeof sortedPlants>>((acc, plant) => {
-    const key = groupBy === "status" ? plant[1].status : plant[1].room
-    if (!acc[key]) acc[key] = []
-    acc[key].push(plant)
-    return acc
-  }, {})
+  const sortedPlants = useMemo(() => {
+    return [...plants].sort((a, b) => {
+      const [, pa] = a
+      const [, pb] = b
+      switch (sortBy) {
+        case "hydration":
+          return pb.hydration - pa.hydration
+        case "lastWatered":
+          return (
+            parse(`${pb.lastWatered} 2024`, "MMM d yyyy", new Date()).getTime() -
+            parse(`${pa.lastWatered} 2024`, "MMM d yyyy", new Date()).getTime()
+          )
+        default:
+          return pa.nickname.localeCompare(pb.nickname)
+      }
+    })
+  }, [plants, sortBy])
 
   return (
     <>
@@ -127,107 +82,23 @@ export default function TodayPage() {
               {plantsCount} plants · Avg hydration {avgHydration}% · {tasksDue} tasks due today
             </p>
           </header>
+          <ControlsBar
+            groupBy={groupBy}
+            sortBy={sortBy}
+            onGroupChange={setGroupBy}
+            onSortChange={setSortBy}
+          />
 
-          <div className="flex gap-4 mb-4 items-center">
-            <select
-              value={groupBy}
-              onChange={(e) => setGroupBy(e.target.value as GroupBy)}
-              className="border rounded p-2"
-            >
-              <option value="none">No grouping</option>
-              <option value="status">Group by status</option>
-              <option value="room">Group by room</option>
-            </select>
-            <select
-              value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as SortBy)}
-              className="border rounded p-2"
-            >
-              <option value="alpha">Alphabetical</option>
-              <option value="hydration">Hydration</option>
-              <option value="lastWatered">Last watered</option>
-            </select>
-          </div>
+          <PlantList plants={sortedPlants} groupBy={groupBy} />
 
-          {groupBy === "none" ? (
-            <section className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {sortedPlants.map(([id, p]) => {
-                const s = p.status.toLowerCase()
-                const tasks = {
-                  water: s.includes("water overdue") || (s.includes("due") && !s.includes("fertilize")) ? 1 : 0,
-                  fertilize: s.includes("fertilize") ? 1 : 0,
-                  notes: s.includes("note") ? 1 : 0,
-                }
-                return (
-                  <Link key={id} href={`/plants/${id}`} className="block">
-                    <PlantCard
-                      nickname={p.nickname}
-                      species={p.species}
-                      status={p.status}
-                      hydration={p.hydration}
-                      photo={p.photos[0]}
-                      hydrationHistory={p.hydrationLog.map((h) => h.value)}
-                      tasks={tasks}
-                      onMarkDone={() => {}}
-                    />
-                  </Link>
-                )
-              })}
-            </section>
-          ) : (
-            <div className="space-y-4">
-              {Object.entries(grouped)
-                .sort((a, b) => a[0].localeCompare(b[0]))
-                .map(([group, items]) => (
-                  <details key={group} open>
-                    <summary className="cursor-pointer font-semibold">
-                      {group} ({items.length})
-                    </summary>
-                    <div className="mt-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                      {items.map(([id, p]) => {
-                        const s = p.status.toLowerCase()
-                        const tasks = {
-                          water:
-                            s.includes("water overdue") ||
-                            (s.includes("due") && !s.includes("fertilize"))
-                              ? 1
-                              : 0,
-                          fertilize: s.includes("fertilize") ? 1 : 0,
-                          notes: s.includes("note") ? 1 : 0,
-                        }
-                        return (
-                          <Link key={id} href={`/plants/${id}`} className="block">
-                            <PlantCard
-                              nickname={p.nickname}
-                              species={p.species}
-                              status={p.status}
-                              hydration={p.hydration}
-                              photo={p.photos[0]}
-                              hydrationHistory={p.hydrationLog.map((h) => h.value)}
-                              tasks={tasks}
-                              onMarkDone={() => {}}
-                            />
-                          </Link>
-                        )
-                      })}
-                    </div>
-                  </details>
-                ))}
-            </div>
-          )}
-
-
-          <section className="mt-8">
-            <h3 className="text-lg font-semibold mb-2">Insights</h3>
-            <ul className="list-disc pl-5 text-sm">
-              <li>{overduePercent}% of plants are overdue</li>
-              <li>Avg watering interval {avgWateringInterval} days</li>
-              <li>Longest on-time streak: {longestStreakPlant || "N/A"}</li>
-              <li>
-                Tasks due tomorrow: {nextDayWaterTasks} water, {nextDayFertilizeTasks} fertilize, {nextDayNoteTasks} notes
-              </li>
-            </ul>
-          </section>
+          <InsightsBlock
+            overduePercent={overduePercent}
+            avgWateringInterval={avgWateringInterval}
+            longestStreakPlant={longestStreakPlant}
+            nextDayWaterTasks={nextDayWaterTasks}
+            nextDayFertilizeTasks={nextDayFertilizeTasks}
+            nextDayNoteTasks={nextDayNoteTasks}
+          />
 
 
           <Footer />

--- a/components/ControlsBar.tsx
+++ b/components/ControlsBar.tsx
@@ -1,0 +1,33 @@
+import { GroupBy, SortBy } from "@/lib/dashboardTypes"
+
+interface ControlsBarProps {
+  groupBy: GroupBy
+  sortBy: SortBy
+  onGroupChange: (g: GroupBy) => void
+  onSortChange: (s: SortBy) => void
+}
+
+export default function ControlsBar({ groupBy, sortBy, onGroupChange, onSortChange }: ControlsBarProps) {
+  return (
+    <div className="flex gap-4 mb-4 items-center">
+      <select
+        value={groupBy}
+        onChange={(e) => onGroupChange(e.target.value as GroupBy)}
+        className="border rounded p-2"
+      >
+        <option value="none">No grouping</option>
+        <option value="status">Group by status</option>
+        <option value="room">Group by room</option>
+      </select>
+      <select
+        value={sortBy}
+        onChange={(e) => onSortChange(e.target.value as SortBy)}
+        className="border rounded p-2"
+      >
+        <option value="alpha">Alphabetical</option>
+        <option value="hydration">Hydration</option>
+        <option value="lastWatered">Last watered</option>
+      </select>
+    </div>
+  )
+}

--- a/components/InsightsBlock.tsx
+++ b/components/InsightsBlock.tsx
@@ -1,0 +1,31 @@
+interface InsightsBlockProps {
+  overduePercent: number
+  avgWateringInterval: number
+  longestStreakPlant: string
+  nextDayWaterTasks: number
+  nextDayFertilizeTasks: number
+  nextDayNoteTasks: number
+}
+
+export default function InsightsBlock({
+  overduePercent,
+  avgWateringInterval,
+  longestStreakPlant,
+  nextDayWaterTasks,
+  nextDayFertilizeTasks,
+  nextDayNoteTasks,
+}: InsightsBlockProps) {
+  return (
+    <section className="mt-8">
+      <h3 className="text-lg font-semibold mb-2">Insights</h3>
+      <ul className="list-disc pl-5 text-sm">
+        <li>{overduePercent}% of plants are overdue</li>
+        <li>Avg watering interval {avgWateringInterval} days</li>
+        <li>Longest on-time streak: {longestStreakPlant || "N/A"}</li>
+        <li>
+          Tasks due tomorrow: {nextDayWaterTasks} water, {nextDayFertilizeTasks} fertilize, {nextDayNoteTasks} notes
+        </li>
+      </ul>
+    </section>
+  )
+}

--- a/components/PlantList.tsx
+++ b/components/PlantList.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from "react"
+import Link from "next/link"
+import PlantCard from "@/components/PlantCard"
+import type { Plant } from "@/lib/plants"
+import { GroupBy } from "@/lib/dashboardTypes"
+
+interface PlantListProps {
+  plants: [string, Plant][]
+  groupBy: GroupBy
+}
+
+export default function PlantList({ plants, groupBy }: PlantListProps) {
+  const grouped = useMemo(() => {
+    if (groupBy === "none") return { All: plants }
+    return plants.reduce<Record<string, [string, Plant][]>>((acc, plant) => {
+      const key = groupBy === "status" ? plant[1].status : plant[1].room
+      if (!acc[key]) acc[key] = []
+      acc[key].push(plant)
+      return acc
+    }, {})
+  }, [plants, groupBy])
+
+  if (groupBy === "none") {
+    return (
+      <section className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {plants.map(([id, p]) => {
+          const s = p.status.toLowerCase()
+          const tasks = {
+            water: s.includes("water overdue") || (s.includes("due") && !s.includes("fertilize")) ? 1 : 0,
+            fertilize: s.includes("fertilize") ? 1 : 0,
+            notes: s.includes("note") ? 1 : 0,
+          }
+          return (
+            <Link key={id} href={`/plants/${id}`} className="block">
+              <PlantCard
+                nickname={p.nickname}
+                species={p.species}
+                status={p.status}
+                hydration={p.hydration}
+                photo={p.photos[0]}
+                hydrationHistory={p.hydrationLog.map((h) => h.value)}
+                tasks={tasks}
+                onMarkDone={() => {}}
+              />
+            </Link>
+          )
+        })}
+      </section>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(grouped)
+        .filter(([group]) => group !== "All")
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([group, items]) => (
+          <details key={group} open>
+            <summary className="cursor-pointer font-semibold">
+              {group} ({items.length})
+            </summary>
+            <div className="mt-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {items.map(([id, p]) => {
+                const s = p.status.toLowerCase()
+                const tasks = {
+                  water:
+                    s.includes("water overdue") ||
+                    (s.includes("due") && !s.includes("fertilize"))
+                      ? 1
+                      : 0,
+                  fertilize: s.includes("fertilize") ? 1 : 0,
+                  notes: s.includes("note") ? 1 : 0,
+                }
+                return (
+                  <Link key={id} href={`/plants/${id}`} className="block">
+                    <PlantCard
+                      nickname={p.nickname}
+                      species={p.species}
+                      status={p.status}
+                      hydration={p.hydration}
+                      photo={p.photos[0]}
+                      hydrationHistory={p.hydrationLog.map((h) => h.value)}
+                      tasks={tasks}
+                      onMarkDone={() => {}}
+                    />
+                  </Link>
+                )
+              })}
+            </div>
+          </details>
+        ))}
+    </div>
+  )
+}

--- a/components/__tests__/ControlsBar.test.tsx
+++ b/components/__tests__/ControlsBar.test.tsx
@@ -1,0 +1,22 @@
+import { render, fireEvent } from '@testing-library/react'
+import ControlsBar from '../ControlsBar'
+
+describe('ControlsBar', () => {
+  it('calls handlers on selection', () => {
+    const onGroup = jest.fn()
+    const onSort = jest.fn()
+    const { getAllByRole } = render(
+      <ControlsBar
+        groupBy="none"
+        sortBy="alpha"
+        onGroupChange={onGroup}
+        onSortChange={onSort}
+      />
+    )
+    const [groupSelect, sortSelect] = getAllByRole('combobox')
+    fireEvent.change(groupSelect, { target: { value: 'status' } })
+    fireEvent.change(sortSelect, { target: { value: 'hydration' } })
+    expect(onGroup).toHaveBeenCalledWith('status')
+    expect(onSort).toHaveBeenCalledWith('hydration')
+  })
+})

--- a/components/__tests__/InsightsBlock.test.tsx
+++ b/components/__tests__/InsightsBlock.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import InsightsBlock from '../InsightsBlock'
+
+describe('InsightsBlock', () => {
+  it('displays metrics', () => {
+    render(
+      <InsightsBlock
+        overduePercent={10}
+        avgWateringInterval={5}
+        longestStreakPlant="Ivy"
+        nextDayWaterTasks={1}
+        nextDayFertilizeTasks={2}
+        nextDayNoteTasks={3}
+      />
+    )
+    expect(screen.getByText(/10% of plants are overdue/)).toBeInTheDocument()
+    expect(screen.getByText(/Avg watering interval 5 days/)).toBeInTheDocument()
+    expect(screen.getByText(/Longest on-time streak: Ivy/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Tasks due tomorrow: 1 water, 2 fertilize, 3 notes/)
+    ).toBeInTheDocument()
+  })
+})

--- a/components/__tests__/PlantList.test.tsx
+++ b/components/__tests__/PlantList.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react'
+import PlantList from '../PlantList'
+import { samplePlants } from '@/lib/plants'
+
+describe('PlantList', () => {
+  it('renders all plants when not grouped', () => {
+    const entries = Object.entries(samplePlants)
+    const { container } = render(<PlantList plants={entries} groupBy="none" />)
+    expect(container.querySelectorAll('a').length).toBe(entries.length)
+  })
+})

--- a/hooks/__tests__/usePlantMetrics.test.ts
+++ b/hooks/__tests__/usePlantMetrics.test.ts
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react'
+import { samplePlants } from '@/lib/plants'
+import usePlantMetrics from '../usePlantMetrics'
+
+describe('usePlantMetrics', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2024-08-28'))
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  it('computes plant metrics', () => {
+    const { result } = renderHook(() =>
+      usePlantMetrics(Object.entries(samplePlants))
+    )
+    expect(result.current.plantsCount).toBe(4)
+    expect(result.current.overduePercent).toBe(25)
+    expect(result.current.longestStreakPlant).toBe('Delilah')
+    expect(result.current.taskStreak).toBe(2)
+    expect(result.current.nextDayWaterTasks).toBe(1)
+  })
+})

--- a/hooks/usePlantMetrics.ts
+++ b/hooks/usePlantMetrics.ts
@@ -1,0 +1,110 @@
+import { useMemo } from "react"
+import { parse, format, subDays, differenceInDays, addDays, isSameDay } from "date-fns"
+import type { Plant } from "@/lib/plants"
+
+export type PlantEntry = [string, Plant]
+
+export interface PlantMetrics {
+  plantsCount: number
+  avgHydration: number
+  tasksDue: number
+  waterTasks: number
+  fertilizeTasks: number
+  noteTasks: number
+  waterOverdue: boolean
+  fertilizeOverdue: boolean
+  noteOverdue: boolean
+  overduePercent: number
+  avgWateringInterval: number
+  longestStreakPlant: string
+  taskStreak: number
+  nextDayWaterTasks: number
+  nextDayFertilizeTasks: number
+  nextDayNoteTasks: number
+}
+
+export function usePlantMetrics(plants: PlantEntry[]): PlantMetrics {
+  return useMemo(() => {
+    const plantsCount = plants.length
+    const avgHydration = Math.round(
+      plants.reduce((sum, [, p]) => sum + p.hydration, 0) / plantsCount
+    )
+    const tasksDue = plants.filter(([, p]) => p.status.toLowerCase().includes("due")).length
+    const waterTasks = plants.filter(([, p]) => {
+      const s = p.status.toLowerCase()
+      return s.includes("water overdue") || (s.includes("due") && !s.includes("fertilize"))
+    }).length
+    const fertilizeTasks = plants.filter(([, p]) => p.status.toLowerCase().includes("fertilize")).length
+    const noteTasks = plants.filter(([, p]) => p.status.toLowerCase().includes("note")).length
+    const waterOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("water overdue"))
+    const fertilizeOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("fertilize overdue"))
+    const noteOverdue = plants.some(([, p]) => p.status.toLowerCase().includes("note overdue"))
+    const overduePercent = Math.round(
+      (plants.filter(([, p]) => p.status.toLowerCase().includes("overdue")).length / plantsCount) * 100
+    )
+    const avgWateringInterval = Math.round(
+      plants.reduce((sum, [, p]) => {
+        return sum + differenceInDays(new Date(), parse(`${p.lastWatered} 2024`, "MMM d yyyy", new Date()))
+      }, 0) / plantsCount
+    )
+    const plantStreaks = plants.map(([, p]) => {
+      const dates = p.events.map((e) => parse(`${e.date} 2024`, "MMM d yyyy", new Date()))
+      const set = new Set(dates.map((d) => format(d, "yyyy-MM-dd")))
+      let streak = 0
+      if (set.size > 0) {
+        let current = dates.reduce((a, b) => (a > b ? a : b))
+        while (set.has(format(current, "yyyy-MM-dd"))) {
+          streak++
+          current = subDays(current, 1)
+        }
+      }
+      return { plant: p.nickname, streak }
+    })
+    const longestStreakPlant = plantStreaks.reduce(
+      (max, p) => (p.streak > max.streak ? p : max),
+      { plant: "", streak: 0 }
+    ).plant
+    const tomorrow = addDays(new Date(), 1)
+    const nextDayTasks = plants.filter(([, p]) =>
+      isSameDay(parse(`${p.nextDue} 2024`, "MMM d yyyy", new Date()), tomorrow)
+    )
+    const nextDayWaterTasks = nextDayTasks.filter(([, p]) => {
+      const s = p.status.toLowerCase()
+      return s.includes("water") || (!s.includes("fertilize") && !s.includes("note"))
+    }).length
+    const nextDayFertilizeTasks = nextDayTasks.filter(([, p]) => p.status.toLowerCase().includes("fertilize")).length
+    const nextDayNoteTasks = nextDayTasks.filter(([, p]) => p.status.toLowerCase().includes("note")).length
+    const eventDates = plants.flatMap(([, p]) =>
+      p.events.map((e) => parse(`${e.date} 2024`, "MMM d yyyy", new Date()))
+    )
+    const dateSet = new Set(eventDates.map((d) => format(d, "yyyy-MM-dd")))
+    let taskStreak = 0
+    if (dateSet.size > 0) {
+      let current = eventDates.reduce((a, b) => (a > b ? a : b))
+      while (dateSet.has(format(current, "yyyy-MM-dd"))) {
+        taskStreak++
+        current = subDays(current, 1)
+      }
+    }
+    return {
+      plantsCount,
+      avgHydration,
+      tasksDue,
+      waterTasks,
+      fertilizeTasks,
+      noteTasks,
+      waterOverdue,
+      fertilizeOverdue,
+      noteOverdue,
+      overduePercent,
+      avgWateringInterval,
+      longestStreakPlant,
+      taskStreak,
+      nextDayWaterTasks,
+      nextDayFertilizeTasks,
+      nextDayNoteTasks,
+    }
+  }, [plants])
+}
+
+export default usePlantMetrics

--- a/lib/dashboardTypes.ts
+++ b/lib/dashboardTypes.ts
@@ -1,0 +1,2 @@
+export type GroupBy = "status" | "room" | "none"
+export type SortBy = "hydration" | "alpha" | "lastWatered"


### PR DESCRIPTION
## Summary
- Extract controls bar, plant list, and insights block into reusable components
- Move dashboard data processing and streak calculations into `usePlantMetrics` hook
- Add unit tests for new components and hook

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5d7ce40832495073ccbc724c5de