### PR TITLE
Add tests for offline fallback and form submissions

### DIFF
--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -1,6 +1,24 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { PlantDetailContent } from '../[id]/page'
 import { ToastProvider } from '@/components/Toast'
+
+jest.mock('@/components/Modal', () => ({
+  __esModule: true,
+  default: ({ isOpen, children }: any) => (isOpen ? <div>{children}</div> : null),
+}))
+jest.mock('@/components/plant-detail/AnalyticsPanel', () => ({
+  __esModule: true,
+  default: () => <div>AnalyticsPanel</div>,
+}))
+jest.mock('@/components/plant-detail/CareTrends', () => ({
+  __esModule: true,
+  default: () => <div>CareTrends</div>,
+}))
+jest.mock('@/components/plant-detail/QuickStats', () => ({
+  __esModule: true,
+  default: () => <div>QuickStats</div>,
+}))
 
 describe('PlantDetailPage', () => {
   afterEach(() => {
@@ -54,5 +72,160 @@ describe('PlantDetailPage', () => {
 
     expect(await screen.findByText(/Timeline/i)).toBeInTheDocument()
     expect(screen.getAllByText(/Watered/i).length).toBeGreaterThan(0)
+  })
+
+  it('falls back to sample data when offline', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('Network error')) as any
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '1' }} />
+      </ToastProvider>
+    )
+
+    expect(
+      await screen.findByText(/Offline data\. Changes may not be saved\./i)
+    ).toBeInTheDocument()
+    expect(await screen.findByText('Delilah')).toBeInTheDocument()
+  })
+
+  it('retries loading on error when Retry is clicked', async () => {
+    const plant = {
+      nickname: 'Test',
+      species: 'Species',
+      status: 'Fine',
+      hydration: 50,
+      lastWatered: 'Aug 1',
+      nextDue: 'Aug 5',
+      lastFertilized: 'Aug 1',
+      nutrientLevel: 50,
+      events: [],
+      photos: [],
+    }
+
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, json: async () => plant })
+    global.fetch = mockFetch as any
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '999' }} />
+      </ToastProvider>
+    )
+
+    expect(await screen.findByText(/Failed to load plant/i)).toBeInTheDocument()
+    await user.click(screen.getByText(/Retry/i))
+    expect(await screen.findByText(/Timeline/i)).toBeInTheDocument()
+  })
+
+  it('submits water form and adds event', async () => {
+    const plant = {
+      nickname: 'Test',
+      species: 'Species',
+      status: 'Fine',
+      hydration: 50,
+      lastWatered: 'Aug 1',
+      nextDue: 'Aug 5',
+      lastFertilized: 'Aug 1',
+      nutrientLevel: 50,
+      events: [],
+      photos: [],
+    }
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => plant,
+    }) as any
+
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '1' }} />
+      </ToastProvider>
+    )
+
+    await screen.findByRole('button', { name: /Water plant/i })
+    await user.click(
+      screen.getByRole('button', { name: /Water plant/i })
+    )
+    await user.type(screen.getByLabelText(/Amount/i), '10')
+    await user.click(screen.getByRole('button', { name: /Confirm/i }))
+    expect(await screen.findByText(/Water added/i)).toBeInTheDocument()
+  })
+
+  it('submits fertilize form and adds event', async () => {
+    const plant = {
+      nickname: 'Test',
+      species: 'Species',
+      status: 'Fine',
+      hydration: 50,
+      lastWatered: 'Aug 1',
+      nextDue: 'Aug 5',
+      lastFertilized: 'Aug 1',
+      nutrientLevel: 50,
+      events: [],
+      photos: [],
+    }
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => plant,
+    }) as any
+
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '1' }} />
+      </ToastProvider>
+    )
+
+    await screen.findByRole('button', { name: /Water plant/i })
+    await user.click(
+      screen.getByRole('button', { name: /Fertilize plant/i })
+    )
+    await user.type(screen.getByLabelText(/Fertilizer/i), 'NPK')
+    await user.click(screen.getByRole('button', { name: /Confirm/i }))
+    expect(await screen.findByText(/Fertilizer added/i)).toBeInTheDocument()
+  })
+
+  it('submits note form and displays note', async () => {
+    const plant = {
+      nickname: 'Test',
+      species: 'Species',
+      status: 'Fine',
+      hydration: 50,
+      lastWatered: 'Aug 1',
+      nextDue: 'Aug 5',
+      lastFertilized: 'Aug 1',
+      nutrientLevel: 50,
+      events: [],
+      photos: [],
+    }
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => plant,
+    }) as any
+
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <PlantDetailContent params={{ id: '1' }} />
+      </ToastProvider>
+    )
+
+    await screen.findByRole('button', { name: /Water plant/i })
+    await user.click(screen.getByRole('button', { name: /Add note/i }))
+    await user.type(screen.getByLabelText(/^Note$/i), 'My note')
+    await user.click(screen.getByRole('button', { name: /Confirm/i }))
+    expect(await screen.findByText(/Note added/i)).toBeInTheDocument()
   })
 })

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -37,9 +37,9 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
     }
 
     document.addEventListener('keydown', onKeyDown)
-    const first = dialogRef.current.querySelector<HTMLElement>(
+    const first = dialogRef.current?.querySelector(
       'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
-    )
+    ) as HTMLElement | null
     first?.focus()
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [isOpen, onClose])


### PR DESCRIPTION
## Summary
- add coverage for offline fallback and retry flows in plant detail page
- exercise water, fertilize and note form submissions
- harden modal focus handling to avoid null ref errors during tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5a89380832486fc5cbf67ec70e1