### PR TITLE
defer charts and modals with dynamic imports

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -1,17 +1,28 @@
 'use client'
 
 import { useEffect, useState, useCallback } from "react"
+import dynamic from "next/dynamic"
 import { ToastProvider, useToast } from "@/components/Toast"
 import PlantDetailSkeleton from "./PlantDetailSkeleton"
-import WaterModal from "@/components/WaterModal"
-import FertilizeModal from "@/components/FertilizeModal"
-import NoteModal from "@/components/NoteModal"
 import HeroSection from "@/components/plant-detail/HeroSection"
 import QuickStats from "@/components/plant-detail/QuickStats"
 import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
 import CareTrends from "@/components/plant-detail/CareTrends"
 import Timeline from "@/components/plant-detail/Timeline"
 import Gallery from "@/components/plant-detail/Gallery"
+
+const WaterModal = dynamic(() => import("@/components/WaterModal"), {
+  ssr: false,
+  loading: () => null,
+})
+const FertilizeModal = dynamic(() => import("@/components/FertilizeModal"), {
+  ssr: false,
+  loading: () => null,
+})
+const NoteModal = dynamic(() => import("@/components/NoteModal"), {
+  ssr: false,
+  loading: () => null,
+})
 import type { Plant, PlantEvent } from "@/components/plant-detail/types"
 import { getWeatherForUser, type Weather } from "@/lib/weather"
 import { samplePlants } from "@/lib/plants"

--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,7 +1,15 @@
 import Link from "next/link"
+import dynamic from "next/dynamic"
 import PlantCard from "@/components/PlantCard"
-import { CareTrendsChart } from "@/components/Charts"
 import { samplePlants } from "@/lib/plants"
+
+const CareTrendsChart = dynamic(
+  () => import("@/components/Charts").then((m) => m.CareTrendsChart),
+  {
+    ssr: false,
+    loading: () => <p>Loading chart...</p>,
+  }
+)
 
 const sampleRooms = {
   "living-room": {

--- a/app/(dashboard)/rooms/page.tsx
+++ b/app/(dashboard)/rooms/page.tsx
@@ -4,12 +4,17 @@ import Link from "next/link"
 import { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { AlertTriangle, HelpCircle, Home, LayoutGrid, List } from "lucide-react"
+import dynamic from "next/dynamic"
 import RoomCard from "@/components/RoomCard"
 import RoomSkeleton from "@/components/RoomSkeleton"
-import RoomModal from "@/components/RoomModal"
 import { getLastSync } from "@/lib/utils"
 import { getRooms, deleteRooms, moveRooms, type Room } from "@/lib/api"
 import Tooltip from "@/components/Tooltip"
+
+const RoomModal = dynamic(() => import("@/components/RoomModal"), {
+  ssr: false,
+  loading: () => null,
+})
 
 export default function RoomsPage() {
   type SortBy = "name" | "hydration" | "tasks"

--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -1,15 +1,36 @@
 "use client"
 
 import { useState } from "react"
-import {
-  TempHumidityChart,
-  VPDGauge,
-  WaterBalanceChart,
-  StressIndexGauge,
-  StressIndexChart,
-  TaskCompletionChart,
-  ComparativeChart,
-} from "@/components/Charts"
+import dynamic from "next/dynamic"
+
+const TempHumidityChart = dynamic(
+  () => import("@/components/Charts").then((m) => m.TempHumidityChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const VPDGauge = dynamic(
+  () => import("@/components/Charts").then((m) => m.VPDGauge),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const WaterBalanceChart = dynamic(
+  () => import("@/components/Charts").then((m) => m.WaterBalanceChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const StressIndexGauge = dynamic(
+  () => import("@/components/Charts").then((m) => m.StressIndexGauge),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const StressIndexChart = dynamic(
+  () => import("@/components/Charts").then((m) => m.StressIndexChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const TaskCompletionChart = dynamic(
+  () => import("@/components/Charts").then((m) => m.TaskCompletionChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const ComparativeChart = dynamic(
+  () => import("@/components/Charts").then((m) => m.ComparativeChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
 import {
   waterBalanceSeries,
   WeatherDay,

--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -1,9 +1,26 @@
 'use client'
 
-import { StressIndexGauge, PlantHealthRadar, NutrientLevelChart, HydrationTrendChart } from '@/components/Charts'
+import dynamic from 'next/dynamic'
 import { calculateStressIndex } from '@/lib/plant-metrics'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
+
+const StressIndexGauge = dynamic(
+  () => import('@/components/Charts').then((m) => m.StressIndexGauge),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const PlantHealthRadar = dynamic(
+  () => import('@/components/Charts').then((m) => m.PlantHealthRadar),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const NutrientLevelChart = dynamic(
+  () => import('@/components/Charts').then((m) => m.NutrientLevelChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
+const HydrationTrendChart = dynamic(
+  () => import('@/components/Charts').then((m) => m.HydrationTrendChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
 
 interface AnalyticsPanelProps {
   plant: Plant

--- a/components/plant-detail/CareTrends.tsx
+++ b/components/plant-detail/CareTrends.tsx
@@ -1,8 +1,13 @@
 'use client'
 
 import { useState } from 'react'
-import { CareTrendsChart } from '@/components/Charts'
+import dynamic from 'next/dynamic'
 import type { PlantEvent } from './types'
+
+const CareTrendsChart = dynamic(
+  () => import('@/components/Charts').then((m) => m.CareTrendsChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
 
 interface CareTrendsProps {
   events: PlantEvent[]

--- a/components/plant-detail/Gallery.tsx
+++ b/components/plant-detail/Gallery.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import Lightbox from '@/components/Lightbox'
+import dynamic from 'next/dynamic'
+
+const Lightbox = dynamic(() => import('@/components/Lightbox'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+})
 
 interface GalleryProps {
   photos: string[]


### PR DESCRIPTION
## Summary
- dynamically load chart components with `next/dynamic` and `ssr: false`
- lazy-load modals and gallery lightbox with dynamic imports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5a5e7ac832484b7ba1a7de2c8dd