### PR TITLE
refactor: extract plant loading helpers

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -108,6 +108,35 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
     toast("Note added")
   }
 
+  async function fetchWeatherForPlant(): Promise<Weather | null> {
+    try {
+      const w = await getWeatherForUser()
+      setWeather(w)
+      return w
+    } catch {
+      return null
+    }
+  }
+
+  async function loadSamplePlant(): Promise<boolean> {
+    const sample = samplePlants[params.id as keyof typeof samplePlants]
+    if (!sample) return false
+
+    const w = await fetchWeatherForPlant()
+    const offlinePlant: Plant = {
+      ...sample,
+      events: (Array.isArray(sample.events) ? sample.events : []).filter(
+        (e: PlantEvent | null): e is PlantEvent =>
+          e !== null && e !== undefined && typeof e.id !== "undefined"
+      ),
+      nextDue: calculateNextDue(sample.lastWatered, w),
+    }
+    setPlant(offlinePlant)
+    setOffline(true)
+    setError(null)
+    return true
+  }
+
   const loadPlant = useCallback(async () => {
     setLoading(true)
     setError(null)
@@ -116,67 +145,19 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
       const res = await fetch(`/api/plants/${params.id}`)
       if (res.ok) {
         const data = await res.json()
-        let w: Weather | null = null
-        try {
-          w = await getWeatherForUser()
-          setWeather(w)
-        } catch {
-          // ignore weather errors
-        }
+        const w = await fetchWeatherForPlant()
         data.nextDue = calculateNextDue(data.lastWatered, w)
         data.events = (Array.isArray(data.events) ? data.events : []).filter(
           (e: PlantEvent | null): e is PlantEvent =>
             e !== null && e !== undefined && typeof e.id !== "undefined"
         )
         setPlant(data)
-      } else {
-        const sample = samplePlants[params.id as keyof typeof samplePlants]
-        if (sample) {
-          let w: Weather | null = null
-          try {
-            w = await getWeatherForUser()
-            setWeather(w)
-          } catch {
-            // ignore weather errors
-          }
-          const offlinePlant: Plant = {
-            ...sample,
-            events: (Array.isArray(sample.events) ? sample.events : []).filter(
-              (e: PlantEvent | null): e is PlantEvent =>
-                e !== null && e !== undefined && typeof e.id !== "undefined"
-            ),
-            nextDue: calculateNextDue(sample.lastWatered, w),
-          }
-          setPlant(offlinePlant)
-          setOffline(true)
-          setError(null)
-        } else {
-          setPlant(null)
-          setError(`Error ${res.status}`)
-        }
+      } else if (!(await loadSamplePlant())) {
+        setPlant(null)
+        setError(`Error ${res.status}`)
       }
     } catch (err) {
-      const sample = samplePlants[params.id as keyof typeof samplePlants]
-      if (sample) {
-        let w: Weather | null = null
-        try {
-          w = await getWeatherForUser()
-          setWeather(w)
-        } catch {
-          // ignore weather errors
-        }
-        const offlinePlant: Plant = {
-          ...sample,
-          events: (Array.isArray(sample.events) ? sample.events : []).filter(
-            (e: PlantEvent | null): e is PlantEvent =>
-              e !== null && e !== undefined && typeof e.id !== "undefined"
-          ),
-          nextDue: calculateNextDue(sample.lastWatered, w),
-        }
-        setPlant(offlinePlant)
-        setOffline(true)
-        setError(null)
-      } else {
+      if (!(await loadSamplePlant())) {
         setPlant(null)
         setError(err instanceof Error ? err.message : String(err))
       }


### PR DESCRIPTION
## Summary
- refactor plant detail page to use helper functions `fetchWeatherForPlant` and `loadSamplePlant`
- streamline `loadPlant` logic by delegating weather fetching and sample fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5a2e5588324818cb5d257a5686d