### PR TITLE
memoize stress index in plant detail

### DIFF
--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -1,27 +1,20 @@
 'use client'
 
 import { StressIndexGauge, PlantHealthRadar, NutrientLevelChart, HydrationTrendChart } from '@/components/Charts'
-import { calculateStressIndex } from '@/lib/plant-metrics'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 
 interface AnalyticsPanelProps {
   plant: Plant
   weather: Weather | null
+  stressIndex: number
 }
 
-export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) {
+export default function AnalyticsPanel({ plant, weather, stressIndex }: AnalyticsPanelProps) {
   return (
     <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <StressIndexGauge
-          value={calculateStressIndex({
-            overdueDays: plant.status === 'Water overdue' ? 1 : 0,
-            hydration: plant.hydration,
-            temperature: weather?.temperature ?? 25,
-            light: 50,
-          })}
-        />
+        <StressIndexGauge value={stressIndex} />
         <PlantHealthRadar
           hydration={plant.hydration}
           lastFertilized={plant.lastFertilized}

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -2,13 +2,12 @@
 
 import Sparkline from '@/components/Sparkline'
 import { Droplet, Sprout, Calendar, Activity } from 'lucide-react'
-import { calculateNutrientAvailability, calculateStressIndex } from '@/lib/plant-metrics'
+import { calculateNutrientAvailability } from '@/lib/plant-metrics'
 import type { Plant } from './types'
-import type { Weather } from '@/lib/weather'
 
 interface QuickStatsProps {
   plant: Plant
-  weather: Weather | null
+  stressIndex: number
 }
 
 function calculateNextFeedDate(lastFertilized: string, nutrientLevel: number) {
@@ -19,7 +18,7 @@ function calculateNextFeedDate(lastFertilized: string, nutrientLevel: number) {
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
 
-export default function QuickStats({ plant, weather }: QuickStatsProps) {
+export default function QuickStats({ plant, stressIndex }: QuickStatsProps) {
   return (
     <section className="grid grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
       {[
@@ -42,14 +41,7 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
         },
         {
           label: 'Stress Score',
-          value: Math.round(
-            calculateStressIndex({
-              overdueDays: plant.status === 'Water overdue' ? 1 : 0,
-              hydration: plant.hydration,
-              temperature: weather?.temperature ?? 25,
-              light: 50,
-            })
-          ),
+          value: stressIndex,
           icon: Activity,
           color: 'text-orange-600',
         },


### PR DESCRIPTION
## Summary
- compute stress index once with useMemo in PlantDetailContent
- pass memoized stress index to QuickStats and StressIndexGauge

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4f59f5874832485c967244bab158e