### PR TITLE
refactor: centralize plant event sanitization

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -12,9 +12,9 @@ import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
 import CareTrends from "@/components/plant-detail/CareTrends"
 import Timeline from "@/components/plant-detail/Timeline"
 import Gallery from "@/components/plant-detail/Gallery"
-import type { Plant, PlantEvent } from "@/components/plant-detail/types"
+import type { Plant } from "@/components/plant-detail/types"
 import { getWeatherForUser, type Weather } from "@/lib/weather"
-import { samplePlants } from "@/lib/plants"
+import { samplePlants, sanitizeEvents } from "@/lib/plants"
 
 
 export function PlantDetailContent({ params }: { params: { id: string } }) {
@@ -124,10 +124,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           // ignore weather errors
         }
         data.nextDue = calculateNextDue(data.lastWatered, w)
-        data.events = (Array.isArray(data.events) ? data.events : []).filter(
-          (e: PlantEvent | null): e is PlantEvent =>
-            e !== null && e !== undefined && typeof e.id !== "undefined"
-        )
+        data.events = sanitizeEvents(data.events)
         setPlant(data)
       } else {
         const sample = samplePlants[params.id as keyof typeof samplePlants]
@@ -141,10 +138,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           }
           const offlinePlant: Plant = {
             ...sample,
-            events: (Array.isArray(sample.events) ? sample.events : []).filter(
-              (e: PlantEvent | null): e is PlantEvent =>
-                e !== null && e !== undefined && typeof e.id !== "undefined"
-            ),
+            events: sanitizeEvents(sample.events),
             nextDue: calculateNextDue(sample.lastWatered, w),
           }
           setPlant(offlinePlant)
@@ -167,10 +161,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
         }
         const offlinePlant: Plant = {
           ...sample,
-          events: (Array.isArray(sample.events) ? sample.events : []).filter(
-            (e: PlantEvent | null): e is PlantEvent =>
-              e !== null && e !== undefined && typeof e.id !== "undefined"
-          ),
+          events: sanitizeEvents(sample.events),
           nextDue: calculateNextDue(sample.lastWatered, w),
         }
         setPlant(offlinePlant)

--- a/lib/__tests__/plants.test.ts
+++ b/lib/__tests__/plants.test.ts
@@ -1,0 +1,15 @@
+import { sanitizeEvents } from '@/lib/plants'
+
+describe('sanitizeEvents', () => {
+  it('filters out invalid events', () => {
+    const events: any = [
+      { id: 1, type: 'water', date: 'Aug 25' },
+      null,
+      undefined,
+      { type: 'note', date: 'Aug 26' },
+    ]
+    expect(sanitizeEvents(events)).toEqual([
+      { id: 1, type: 'water', date: 'Aug 25' },
+    ])
+  })
+})

--- a/lib/plants.ts
+++ b/lib/plants.ts
@@ -21,6 +21,13 @@ export interface Plant {
   carePlan?: string
 }
 
+export function sanitizeEvents(events: unknown): PlantEvent[] {
+  return (Array.isArray(events) ? events : []).filter(
+    (e: any): e is PlantEvent =>
+      e !== null && e !== undefined && typeof e.id !== "undefined"
+  )
+}
+
 export const samplePlants: Record<string, Plant> = {
   "1": {
     nickname: "Delilah",


### PR DESCRIPTION
## Summary
- add sanitizeEvents helper to filter invalid plant events
- reuse sanitization when applying API or sample data
- test sanitizeEvents

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f59881108324a73be7c2fc143b7a