### PR TITLE
refactor: reuse plant types

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -12,9 +12,8 @@ import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
 import CareTrends from "@/components/plant-detail/CareTrends"
 import Timeline from "@/components/plant-detail/Timeline"
 import Gallery from "@/components/plant-detail/Gallery"
-import type { Plant, PlantEvent } from "@/components/plant-detail/types"
 import { getWeatherForUser, type Weather } from "@/lib/weather"
-import { samplePlants } from "@/lib/plants"
+import { samplePlants, type Plant, type PlantEvent } from "@/lib/plants"
 
 
 export function PlantDetailContent({ params }: { params: { id: string } }) {


### PR DESCRIPTION
## Summary
- import Plant and PlantEvent from central lib
- remove outdated plant type imports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f591afe083249bbf59b85d9dad29