### PR TITLE
feat: filter today view for due plants

### DIFF
--- a/app/(dashboard)/__tests__/page.test.tsx
+++ b/app/(dashboard)/__tests__/page.test.tsx
@@ -14,4 +14,12 @@ describe('Dashboard page layout', () => {
     expect(grid).toHaveClass('lg:grid-cols-3')
     expect(grid).toHaveClass('xl:grid-cols-4')
   })
+
+  it('renders only plants with due tasks', () => {
+    const { queryByText } = render(<TodayPage />)
+    expect(queryByText('Delilah')).toBeInTheDocument()
+    expect(queryByText('Ivy')).toBeInTheDocument()
+    expect(queryByText('Sunny')).not.toBeInTheDocument()
+    expect(queryByText('Figgy')).not.toBeInTheDocument()
+  })
 })

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -15,7 +15,13 @@ export default function TodayPage() {
   const [groupBy, setGroupBy] = useState<GroupBy>("none")
   const [sortBy, setSortBy] = useState<SortBy>("alpha")
 
-  const plants = useMemo(() => Object.entries(samplePlants), [])
+  const plants = useMemo(
+    () =>
+      Object.entries(samplePlants).filter(([, p]) =>
+        p.status.toLowerCase().includes("due")
+      ),
+    []
+  )
   const {
     plantsCount,
     avgHydration,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,9 +13,9 @@ Flora-Science is a plant care companion designed for **clarity**, **low-friction
 ---
 
 ## 🌱 Phase 1 – Core Views
-- [ ] **Today View**
-  - Show all plants due today
-  - Hydration, fertilizing, and notes at a glance
+- [x] **Today View**
+  - [x] Show all plants due today
+  - [x] Hydration, fertilizing, and notes at a glance
 - [ ] **Rooms View**
   - Group plants by room
   - Show average hydration + tasks due


### PR DESCRIPTION
## Summary
- show only plants with due tasks on the Today dashboard
- test that Today page filters non-due plants
- check off Today View in roadmap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5018c35e48324ad3d80f4d2d30515