### PR TITLE
feat: add room detail view api

### DIFF
--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -1,63 +1,56 @@
-import Link from "next/link"
-import dynamic from "next/dynamic"
-import PlantCard from "@/components/PlantCard"
-import { samplePlants } from "@/lib/plants"
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import dynamic from 'next/dynamic'
+import PlantCard from '@/components/PlantCard'
+import { samplePlants } from '@/lib/plants'
+import { sampleRooms, type RoomDetail } from '@/lib/rooms'
 
 const CareTrendsChart = dynamic(
-  () => import("@/components/Charts").then((m) => m.CareTrendsChart),
+  () => import('@/components/Charts').then((m) => m.CareTrendsChart),
   {
     ssr: false,
     loading: () => <p>Loading chart...</p>,
   }
 )
 
-const sampleRooms = {
-  "living-room": {
-    name: "Living Room",
-    hydration: 72,
-    tasks: 2,
-    plants: [
-      { id: "1", nickname: "Delilah", species: "Monstera deliciosa", status: "Water overdue", hydration: 72 },
-      { id: "3", nickname: "Ivy", species: "Epipremnum aureum", status: "Due today", hydration: 70 }
-    ],
-    events: [
-      { type: "water", date: "2024-01-10" },
-      { type: "fertilize", date: "2024-02-12" }
-    ]
-  },
-  "bedroom": {
-    name: "Bedroom",
-    hydration: 65,
-    tasks: 1,
-    plants: [
-      { id: "2", nickname: "Sunny", species: "Sansevieria trifasciata", status: "Fine", hydration: 90 }
-    ],
-    events: [
-      { type: "water", date: "2024-03-05" }
-    ]
-  },
-  "office": {
-    name: "Office",
-    hydration: 82,
-    tasks: 0,
-    plants: [
-      { id: "4", nickname: "Figgy", species: "Ficus lyrata", status: "Fertilize suggested", hydration: 75 }
-    ],
-    events: []
-  }
-}
-
 export default function RoomDetailPage({ params }: { params: { id: string } }) {
-  const room = sampleRooms[params.id as keyof typeof sampleRooms]
+  const [room, setRoom] = useState<RoomDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function loadRoom() {
+      try {
+        const res = await fetch(`/api/rooms/${params.id}`)
+        if (res.ok) {
+          const data = await res.json()
+          setRoom(data)
+        } else {
+          setRoom(sampleRooms[params.id as keyof typeof sampleRooms] ?? null)
+        }
+      } catch {
+        setRoom(sampleRooms[params.id as keyof typeof sampleRooms] ?? null)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadRoom()
+  }, [params.id])
 
   return (
     <main className="flex-1 bg-white dark:bg-gray-900">
       <div className="p-6 space-y-6">
-        <Link href="/rooms" className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
+        <Link
+          href="/rooms"
+          className="inline-block px-3 py-1 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+        >
           ← Back to Rooms
         </Link>
 
-        {!room ? (
+        {loading ? (
+          <p>Loading...</p>
+        ) : !room ? (
           <div className="rounded-lg border p-6 dark:border-gray-700">
             <h2 className="text-xl font-bold">Room not found</h2>
             <p className="text-sm text-gray-500 mt-1">ID: {params.id}</p>

--- a/app/(dashboard)/rooms/__tests__/page.test.tsx
+++ b/app/(dashboard)/rooms/__tests__/page.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import RoomDetailPage from '../[id]/page'
+
+jest.mock('@/components/Charts', () => ({
+  CareTrendsChart: () => <div>CareTrendsChart</div>,
+}))
+
+describe('RoomDetailPage', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('displays room data from API', async () => {
+    const room = {
+      name: 'Test Room',
+      hydration: 50,
+      tasks: 1,
+      status: 'healthy',
+      tags: [],
+      plants: [],
+      events: [],
+    }
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => room,
+    }) as any
+
+    render(<RoomDetailPage params={{ id: 'test' }} />)
+
+    expect(await screen.findByText('Test Room')).toBeInTheDocument()
+    expect(screen.getByText(/50%/)).toBeInTheDocument()
+  })
+
+  it('handles missing room', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as any
+
+    render(<RoomDetailPage params={{ id: 'missing' }} />)
+
+    expect(await screen.findByText(/Room not found/)).toBeInTheDocument()
+  })
+})

--- a/app/api/rooms/[id]/route.ts
+++ b/app/api/rooms/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { sampleRooms } from '@/lib/rooms'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const room = sampleRooms[params.id as keyof typeof sampleRooms]
+  if (!room) {
+    return NextResponse.json({ error: 'Room not found' }, { status: 404 })
+  }
+  return NextResponse.json(room)
+}

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -1,37 +1,20 @@
 import { NextResponse } from 'next/server'
+import { sampleRooms } from '@/lib/rooms'
 
-const sampleRooms = [
-  {
-    id: 'living-room',
-    name: 'Living Room',
-    status: 'healthy',
-    avgHydration: 72,
-    tasksDue: 2,
-    tags: ['indoor', 'bright']
-  },
-  {
-    id: 'bedroom',
-    name: 'Bedroom',
-    status: 'needs_water',
-    avgHydration: 65,
-    tasksDue: 1,
-    tags: ['indoor', 'low-light']
-  },
-  {
-    id: 'office',
-    name: 'Office',
-    status: 'warning',
-    avgHydration: 82,
-    tasksDue: 0,
-    tags: ['indoor', 'workspace']
-  }
-]
+const roomList = Object.entries(sampleRooms).map(([id, room]) => ({
+  id,
+  name: room.name,
+  status: room.status,
+  avgHydration: room.hydration,
+  tasksDue: room.tasks,
+  tags: room.tags,
+}))
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const page = parseInt(searchParams.get('page') ?? '1', 10)
   const limit = parseInt(searchParams.get('limit') ?? '10', 10)
   const start = (page - 1) * limit
-  const data = sampleRooms.slice(start, start + limit)
+  const data = roomList.slice(start, start + limit)
   return NextResponse.json(data)
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@ Flora-Science is a plant care companion designed for **clarity**, **low-friction
   - Quick Stats (hydration, last watered, next due)
   - Timeline of events (water, fertilize, notes, photos)
   - Gallery of plant photos
-- [ ] **Room Detail View**
+- [x] **Room Detail View**
   - Show all plants in room
   - Room-level stats
 

--- a/lib/rooms.ts
+++ b/lib/rooms.ts
@@ -1,0 +1,64 @@
+export interface RoomPlant {
+  id: string
+  nickname: string
+  species: string
+  status: string
+  hydration: number
+}
+
+export interface RoomEvent {
+  type: string
+  date: string
+}
+
+export interface RoomDetail {
+  name: string
+  hydration: number
+  tasks: number
+  status: 'healthy' | 'needs_water' | 'warning'
+  tags: string[]
+  plants: RoomPlant[]
+  events: RoomEvent[]
+}
+
+export const sampleRooms: Record<string, RoomDetail> = {
+  'living-room': {
+    name: 'Living Room',
+    hydration: 72,
+    tasks: 2,
+    status: 'healthy',
+    tags: ['indoor', 'bright'],
+    plants: [
+      { id: '1', nickname: 'Delilah', species: 'Monstera deliciosa', status: 'Water overdue', hydration: 72 },
+      { id: '3', nickname: 'Ivy', species: 'Epipremnum aureum', status: 'Due today', hydration: 70 },
+    ],
+    events: [
+      { type: 'water', date: '2024-01-10' },
+      { type: 'fertilize', date: '2024-02-12' },
+    ],
+  },
+  bedroom: {
+    name: 'Bedroom',
+    hydration: 65,
+    tasks: 1,
+    status: 'needs_water',
+    tags: ['indoor', 'low-light'],
+    plants: [
+      { id: '2', nickname: 'Sunny', species: 'Sansevieria trifasciata', status: 'Fine', hydration: 90 },
+    ],
+    events: [
+      { type: 'water', date: '2024-03-05' },
+    ],
+  },
+  office: {
+    name: 'Office',
+    hydration: 82,
+    tasks: 0,
+    status: 'warning',
+    tags: ['indoor', 'workspace'],
+    plants: [
+      { id: '4', nickname: 'Figgy', species: 'Ficus lyrata', status: 'Fertilize suggested', hydration: 75 },
+    ],
+    events: [],
+  },
+}


### PR DESCRIPTION
## Summary
- add sample room dataset and API endpoints for list and detail
- load room detail client-side with fallback to sample data
- mark room detail view as complete in roadmap

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b509b584308324856d5efbb52a5ca8