### PR TITLE
Refactor QuickStats layout and integrate into Hero

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -5,7 +5,6 @@ import dynamic from "next/dynamic"
 import { ToastProvider, useToast } from "@/components/Toast"
 import PlantDetailSkeleton from "./PlantDetailSkeleton"
 import HeroSection from "@/components/plant-detail/HeroSection"
-import QuickStats from "@/components/plant-detail/QuickStats"
 import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
 import CareTrends from "@/components/plant-detail/CareTrends"
 import Timeline from "@/components/plant-detail/Timeline"
@@ -217,11 +216,11 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
 
             <HeroSection
               plant={plant}
+              weather={weather}
               onWater={handleWater}
               onFertilize={handleFertilize}
               onAddNote={handleAddNote}
             />
-            <QuickStats plant={plant} weather={weather} />
             <AnalyticsPanel plant={plant} weather={weather} />
             <CareTrends events={plant.events} />
             <Timeline events={plant.events} />

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -3,10 +3,13 @@
 import Image from 'next/image'
 import { Droplet, Sprout, FileText } from 'lucide-react'
 import { getHydrationProgress } from '@/components/PlantCard'
+import QuickStats from './QuickStats'
 import type { Plant } from './types'
+import type { Weather } from '@/lib/weather'
 
 interface HeroSectionProps {
   plant: Plant
+  weather: Weather | null
   onWater: () => void
   onFertilize: () => void
   onAddNote: () => void
@@ -14,6 +17,7 @@ interface HeroSectionProps {
 
 export default function HeroSection({
   plant,
+  weather,
   onWater,
   onFertilize,
   onAddNote,
@@ -45,6 +49,8 @@ export default function HeroSection({
           <p className="italic text-gray-200">{plant.species}</p>
         </div>
       </div>
+
+      <QuickStats plant={plant} weather={weather} />
 
       <div className="flex flex-wrap justify-center sm:justify-start gap-3">
         <button

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -21,7 +21,7 @@ function calculateNextFeedDate(lastFertilized: string, nutrientLevel: number) {
 
 export default function QuickStats({ plant, weather }: QuickStatsProps) {
   return (
-    <section className="grid grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+    <section className="flex flex-wrap justify-between gap-4 md:gap-6">
       {[
         { label: 'Last Watered', value: plant.lastWatered, icon: Droplet },
         { label: 'Next Water Due', value: plant.nextDue, icon: Calendar },
@@ -56,7 +56,7 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
       ].map(({ label, value, icon: Icon, spark, color }) => (
         <div
           key={label}
-          className="flex flex-col items-center justify-center gap-1 rounded-lg border p-4 bg-white shadow-sm dark:bg-gray-900 dark:border-gray-700"
+          className="flex flex-col items-center justify-center gap-1 p-4 rounded-md border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800 flex-1 min-w-[150px]"
         >
           <Icon className={`h-5 w-5 text-gray-500 dark:text-gray-400 ${color ?? ''}`} />
           <span className="text-xl font-bold text-gray-900 dark:text-white">


### PR DESCRIPTION
## Summary
- display plant stats in a flexible horizontal strip that wraps on small screens
- move QuickStats into HeroSection beneath the plant photo
- streamline stat card styling for a cleaner dashboard look

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a211c1848324b1301eefaa3017d6