### PR TITLE
feat: add care streak chart and stress labels

### DIFF
--- a/app/(dashboard)/rooms/[id]/page.tsx
+++ b/app/(dashboard)/rooms/[id]/page.tsx
@@ -7,8 +7,8 @@ import PlantCard from '@/components/PlantCard'
 import { samplePlants } from '@/lib/plants'
 import { sampleRooms, type RoomDetail } from '@/lib/rooms'
 
-const CareTrendsChart = dynamic(
-  () => import('@/components/Charts').then((m) => m.CareTrendsChart),
+const CareStreak = dynamic(
+  () => import('@/components/Charts').then((m) => m.CareStreak),
   {
     ssr: false,
     loading: () => <p>Loading chart...</p>,
@@ -86,7 +86,7 @@ export default function RoomDetailPage({ params }: { params: { id: string } }) {
 
             <section>
               <h2 className="font-semibold mb-2">Care Trends</h2>
-              <CareTrendsChart events={room.events ?? []} />
+              <CareStreak events={room.events ?? []} />
             </section>
           </>
         )}

--- a/app/(dashboard)/rooms/__tests__/page.test.tsx
+++ b/app/(dashboard)/rooms/__tests__/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import RoomDetailPage from '../[id]/page'
 
 jest.mock('@/components/Charts', () => ({
-  CareTrendsChart: () => <div>CareTrendsChart</div>,
+  CareStreak: () => <div>CareStreak</div>,
 }))
 
 describe('RoomDetailPage', () => {

--- a/components/plant-detail/CareTrends.tsx
+++ b/components/plant-detail/CareTrends.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import type { PlantEvent } from './types'
 
-const CareTrendsChart = dynamic(
-  () => import('@/components/Charts').then((m) => m.CareTrendsChart),
+const CareStreak = dynamic(
+  () => import('@/components/Charts').then((m) => m.CareStreak),
   { ssr: false, loading: () => <p>Loading chart...</p> }
 )
 
@@ -14,32 +13,13 @@ interface CareTrendsProps {
 }
 
 export default function CareTrends({ events }: CareTrendsProps) {
-  const [view, setView] = useState<'monthly' | 'weekly' | 'yearly'>('monthly')
-
   return (
     <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
-      <div className="flex items-center justify-between mb-4">
+      <div className="mb-4">
         <h2 className="text-lg font-semibold">Care Trends</h2>
-        <div className="flex gap-2 text-sm">
-          {(['monthly', 'weekly', 'yearly'] as const).map((v) => (
-            <button
-              key={v}
-              onClick={() => setView(v)}
-              className={`px-3 py-1 rounded-full capitalize transition-colors ${
-                view === v
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
-              }`}
-            >
-              {v}
-            </button>
-          ))}
-        </div>
       </div>
-      <p className="text-sm text-gray-500 mb-2">
-        100% tasks completed on time this month
-      </p>
-      <CareTrendsChart events={events} view={view} />
+      <p className="text-sm text-gray-500 mb-2">Recent care activity</p>
+      <CareStreak events={events} />
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- shade hydration trend chart with low/optimal/high reference bands
- label stress gauge severity with color-coded text
- replace care trends bar chart with new 30-day care streak view

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a727b4c0832495b1164989933d96