### PR TITLE
Group timeline events by week with relative dates

### DIFF
--- a/components/plant-detail/Timeline.tsx
+++ b/components/plant-detail/Timeline.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Droplet, Sprout, FileText } from 'lucide-react'
+import { format, formatDistanceToNow, startOfWeek } from 'date-fns'
 import type { PlantEvent } from './types'
 
 const EVENT_TYPES = {
@@ -25,50 +26,82 @@ const EVENT_TYPES = {
 export default function Timeline({ events }: { events: PlantEvent[] }) {
   const [expandedId, setExpandedId] = useState<number | null>(null)
 
+  const processed = events
+    ?.filter((e): e is PlantEvent => e !== null && e !== undefined)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
+  const grouped = processed?.reduce((acc, e) => {
+    const weekStart = startOfWeek(new Date(e.date))
+    const key = format(weekStart, 'yyyy-MM-dd')
+    acc[key] = acc[key] || []
+    acc[key].push(e)
+    return acc
+  }, {} as Record<string, PlantEvent[]>)
+
+  const weeks = grouped
+    ? Object.keys(grouped).sort(
+        (a, b) => new Date(b).getTime() - new Date(a).getTime(),
+      )
+    : []
+
   return (
     <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-4">
       <h2 className="text-lg font-semibold">Timeline</h2>
-      {!events || events.length === 0 ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
+      {!weeks.length ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No activity yet.
+        </p>
       ) : (
-        <ol className="relative border-l ml-4">
-          {events
-            .filter((e): e is PlantEvent => e !== null && e !== undefined)
-            .map((e) => {
-              const type =
-                EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ?? EVENT_TYPES.note
-              const Icon = type.icon
-              const dot =
-                e.type === 'water'
-                  ? 'bg-blue-500'
-                  : e.type === 'fertilize'
-                  ? 'bg-green-500'
-                  : 'bg-purple-500'
-              const open = expandedId === e.id
-              return (
-                <li key={e.id} className="mb-6 ml-6">
-                  <span
-                    className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full text-white ${dot} ring-2 ring-white transition-transform hover:scale-110`}
-                  >
-                    <Icon className="w-3 h-3" />
-                  </span>
-                  <button
-                    onClick={() => setExpandedId(open ? null : e.id)}
-                    className="text-left w-full"
-                  >
-                    <time className="block text-xs text-gray-500">{e.date}</time>
-                    <span className="font-medium">{type.label}</span>
-                  </button>
-                  {open && (
-                    <div className="mt-2 p-3 rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-700 text-sm">
-                      {e.type === 'note' && e.note}
-                    </div>
-                  )}
-                </li>
-              )
-            })}
-        </ol>
+        <div className="space-y-6">
+          {weeks.map((week, index) => {
+            const weekDate = new Date(week)
+            const weekEvents = grouped[week]
+            return (
+              <div key={week}>
+                <h3 className="text-sm font-semibold mb-2">
+                  Week of {format(weekDate, 'MMM d')}
+                </h3>
+                <ol className="relative border-l ml-4">
+                  {weekEvents.map((e) => {
+                    const type =
+                      EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ??
+                      EVENT_TYPES.note
+                    const Icon = type.icon
+                    const open = expandedId === e.id
+                    return (
+                      <li key={e.id} className="mb-6 ml-6">
+                        <span className="absolute -left-3 flex items-center justify-center w-6 h-6 text-gray-400">
+                          <Icon className="w-4 h-4" />
+                        </span>
+                        <button
+                          onClick={() => setExpandedId(open ? null : e.id)}
+                          className="text-left w-full"
+                        >
+                          <time className="block text-xs text-gray-500">
+                            {formatDistanceToNow(new Date(e.date), {
+                              addSuffix: true,
+                            })}
+                          </time>
+                          <span className="font-medium">{type.label}</span>
+                        </button>
+                        {open && (
+                          <div className="mt-2 p-3 rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-700 text-sm">
+                            {e.type === 'note' && e.note}
+                          </div>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ol>
+                {index < weeks.length - 1 && (
+                  <hr className="my-4 border-gray-200 dark:border-gray-700" />
+                )}
+              </div>
+            )
+          })}
+        </div>
       )}
     </section>
   )
 }
+


### PR DESCRIPTION
## Summary
- format plant event dates as relative time with date-fns
- replace timeline dots with monochrome icons and group events by week
- add dividers between weekly sections for clarity

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a8be6f108324afd2e9129fd7ec66