### PR TITLE
refactor: soften plant detail visuals

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -240,7 +240,6 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           </div>
         ) : (
           <>
-
             <HeroSection
               plant={plant}
               weather={weather}
@@ -248,10 +247,18 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               onFertilize={handleFertilize}
               onAddNote={handleAddNote}
             />
-            <AnalyticsPanel plant={plant} weather={weather} />
-            <CareTrends events={plant.events} />
-            <Timeline events={plant.events} />
-            <Gallery photos={plant.photos} nickname={plant.nickname} />
+            <div className="mt-8">
+              <AnalyticsPanel plant={plant} weather={weather} />
+            </div>
+            <div className="mt-8">
+              <CareTrends events={plant.events} />
+            </div>
+            <div className="mt-8">
+              <Timeline events={plant.events} />
+            </div>
+            <div className="mt-8">
+              <Gallery photos={plant.photos} nickname={plant.nickname} />
+            </div>
           </>
         )}
       </div>

--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -29,7 +29,7 @@ interface AnalyticsPanelProps {
 
 export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) {
   return (
-    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-6">
+    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800 space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <StressIndexGauge
           value={calculateStressIndex({

--- a/components/plant-detail/CareTrends.tsx
+++ b/components/plant-detail/CareTrends.tsx
@@ -14,7 +14,7 @@ interface CareTrendsProps {
 
 export default function CareTrends({ events }: CareTrendsProps) {
   return (
-    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
+    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800">
       <div className="mb-4">
         <h2 className="text-lg font-semibold">Care Trends</h2>
       </div>

--- a/components/plant-detail/Gallery.tsx
+++ b/components/plant-detail/Gallery.tsx
@@ -1,25 +1,137 @@
 'use client'
 
-import dynamic from 'next/dynamic'
-
-const Lightbox = dynamic(() => import('@/components/Lightbox'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-})
+import { useCallback, useEffect, useState } from 'react'
+import Image from 'next/image'
 
 interface GalleryProps {
-  photos: string[]
+  photos?: string[]
   nickname: string
 }
 
-export default function Gallery({ photos, nickname }: GalleryProps) {
+export default function Gallery({ photos = [], nickname }: GalleryProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+  const length = photos.length
+
+  const close = useCallback(() => setOpenIndex(null), [])
+  const showPrev = useCallback(
+    () =>
+      setOpenIndex((idx) =>
+        idx === null ? idx : (idx + length - 1) % length,
+      ),
+    [length],
+  )
+  const showNext = useCallback(
+    () =>
+      setOpenIndex((idx) => (idx === null ? idx : (idx + 1) % length)),
+    [length],
+  )
+
+  useEffect(() => {
+    if (openIndex === null) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        close()
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        showNext()
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        showPrev()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [openIndex, close, showNext, showPrev])
+
   return (
-    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900">
+    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800">
       <h2 className="text-lg font-semibold mb-4">Gallery</h2>
-      {photos && photos.length > 0 ? (
-        <Lightbox
-          images={photos.map((src, i) => ({ src, alt: `${nickname} photo ${i + 1}` }))}
-        />
+      {length > 0 ? (
+        <>
+          {openIndex !== null && (
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/75"
+            >
+              <div className="relative">
+                <Image
+                  src={photos[openIndex]}
+                  alt={`${nickname} photo ${openIndex + 1}`}
+                  width={1200}
+                  height={800}
+                  sizes="100vw"
+                  className="max-h-screen max-w-full object-contain"
+                  loading="lazy"
+                />
+                <button
+                  aria-label="Close image"
+                  onClick={close}
+                  className="absolute top-2 right-2 text-white text-3xl"
+                >
+                  ×
+                </button>
+                  {length > 1 && (
+                  <>
+                    <button
+                      aria-label="Previous image"
+                      onClick={showPrev}
+                      className="absolute left-2 top-1/2 -translate-y-1/2 text-white text-3xl"
+                    >
+                      ‹
+                    </button>
+                    <button
+                      aria-label="Next image"
+                      onClick={showNext}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-white text-3xl"
+                    >
+                      ›
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <button
+              onClick={() => setOpenIndex(0)}
+              className="focus:outline-none w-full h-64"
+              aria-label={`View image 1 of ${length}`}
+            >
+              <Image
+                src={photos[0]}
+                alt={`${nickname} photo 1`}
+                width={800}
+                height={600}
+                className="w-full h-64 object-cover rounded-lg"
+                loading="lazy"
+              />
+            </button>
+            {length > 1 && (
+              <div className="grid grid-cols-3 gap-4 mt-4">
+                {photos.slice(1).map((src, i) => (
+                  <button
+                    key={i + 1}
+                    onClick={() => setOpenIndex(i + 1)}
+                    className="focus:outline-none"
+                    aria-label={`View image ${i + 2} of ${length}`}
+                  >
+                    <Image
+                      src={src}
+                      alt={`${nickname} photo ${i + 2}`}
+                      width={400}
+                      height={400}
+                      className="w-full h-24 object-cover rounded-lg"
+                      loading="lazy"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
       ) : (
         <p className="text-sm text-gray-500 dark:text-gray-400">No photos available.</p>
       )}

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -79,7 +79,7 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
       ].map(({ label, value, icon: Icon, spark, color }) => (
         <div
           key={label}
-          className="flex flex-col items-center justify-center gap-1 p-4 rounded-md border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800 flex-1 min-w-[150px]"
+          className="flex flex-col items-center justify-center gap-1 p-4 rounded-md bg-gray-50 dark:bg-gray-800 flex-1 min-w-[150px]"
         >
           <Icon className={`h-5 w-5 text-gray-500 dark:text-gray-400 ${color ?? ''}`} />
           <span className="text-xl font-bold text-gray-900 dark:text-white">

--- a/components/plant-detail/Timeline.tsx
+++ b/components/plant-detail/Timeline.tsx
@@ -45,7 +45,7 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
     : []
 
   return (
-    <section className="rounded-xl border p-6 shadow-sm bg-white dark:bg-gray-900 space-y-4">
+    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800 space-y-4">
       <h2 className="text-lg font-semibold">Timeline</h2>
       {!weeks.length ? (
         <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -85,7 +85,7 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
                           <span className="font-medium">{type.label}</span>
                         </button>
                         {open && (
-                          <div className="mt-2 p-3 rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-700 text-sm">
+                          <div className="mt-2 p-3 rounded-lg bg-gray-50 dark:bg-gray-800 text-sm">
                             {e.type === 'note' && e.note}
                           </div>
                         )}


### PR DESCRIPTION
## Summary
- replace bordered panels with soft tinted backgrounds
- standardize spacing between plant detail sections
- rework gallery to feature a large lead image and thumbnail grid

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ab54de2083249cd2857c376aa74c