### PR TITLE
feat: display care due dates in plant hero

### DIFF
--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@/components/plant-detail/CareTrends', () => ({
 jest.mock('@/components/plant-detail/QuickStats', () => ({
   __esModule: true,
   default: () => <div>QuickStats</div>,
+  calculateNextFeedDate: () => 'Aug 5',
 }))
 
 describe('PlantDetailPage', () => {

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -2,8 +2,9 @@
 
 import Image from 'next/image'
 import { Droplet, Sprout, FileText } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { getHydrationProgress } from '@/components/PlantCard'
-import QuickStats from './QuickStats'
+import QuickStats, { calculateNextFeedDate } from './QuickStats'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 
@@ -23,6 +24,29 @@ export default function HeroSection({
   onAddNote,
 }: HeroSectionProps) {
   const progress = getHydrationProgress(plant.hydration)
+  const [nextWaterDue, setNextWaterDue] = useState(plant.nextDue)
+  const [nextFeedDate, setNextFeedDate] = useState(
+    calculateNextFeedDate(plant.lastFertilized, plant.nutrientLevel ?? 100)
+  )
+
+  useEffect(() => {
+    setNextWaterDue(plant.nextDue)
+  }, [plant.nextDue])
+
+  useEffect(() => {
+    setNextFeedDate(
+      calculateNextFeedDate(plant.lastFertilized, plant.nutrientLevel ?? 100)
+    )
+  }, [plant.lastFertilized, plant.nutrientLevel])
+
+  function isPast(dateStr: string) {
+    const year = new Date().getFullYear()
+    const date = new Date(`${dateStr} ${year}`)
+    return date < new Date()
+  }
+
+  const waterOverdue = isPast(nextWaterDue)
+  const feedOverdue = isPast(nextFeedDate)
 
   return (
     <section className="space-y-4">
@@ -56,18 +80,18 @@ export default function HeroSection({
         <button
           onClick={onWater}
           aria-label="Water plant"
-          className="flex items-center gap-1 px-4 py-2 rounded-full bg-blue-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600"
+          className={`flex items-center gap-1 px-4 py-2 rounded-full bg-blue-600 ${waterOverdue ? 'text-amber-600' : 'text-white'} transition-transform duration-150 hover:scale-105 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600`}
         >
           <Droplet className="h-4 w-4" />
-          Water
+          {`Water (Due ${nextWaterDue})`}
         </button>
         <button
           onClick={onFertilize}
           aria-label="Fertilize plant"
-          className="flex items-center gap-1 px-4 py-2 rounded-full bg-green-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:bg-green-500 dark:hover:bg-green-600"
+          className={`flex items-center gap-1 px-4 py-2 rounded-full bg-green-600 ${feedOverdue ? 'text-amber-600' : 'text-white'} transition-transform duration-150 hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:bg-green-500 dark:hover:bg-green-600`}
         >
           <Sprout className="h-4 w-4" />
-          Fertilize
+          {`Fertilize (Due ${nextFeedDate})`}
         </button>
         <button
           onClick={onAddNote}

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -11,7 +11,10 @@ interface QuickStatsProps {
   weather: Weather | null
 }
 
-function calculateNextFeedDate(lastFertilized: string, nutrientLevel: number) {
+export function calculateNextFeedDate(
+  lastFertilized: string,
+  nutrientLevel: number
+) {
   const current = calculateNutrientAvailability(lastFertilized, nutrientLevel)
   const daysLeft = Math.max(0, Math.ceil((current - 30) / 2))
   const date = new Date()


### PR DESCRIPTION
## Summary
- show next watering and feeding dates on hero action buttons
- highlight overdue care in amber
- export feed-date helper and adjust tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5adf26c90832489b2ddeddec0b6fd