### PR TITLE
Refine plant detail hero and quick stats layout

### DIFF
--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -89,7 +89,7 @@ describe('PlantDetailPage', () => {
     expect(
       await screen.findByText(/Offline data\. Changes may not be saved\./i)
     ).toBeInTheDocument()
-    expect(await screen.findByText('Delilah')).toBeInTheDocument()
+    expect(await screen.findByText(/Delilah/i)).toBeInTheDocument()
   })
 
   it('retries loading on error when Retry is clicked', async () => {

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 import { Droplet, Sprout, FileText } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
 import { getHydrationProgress } from '@/components/PlantCard'
 import QuickStats, { calculateNextFeedDate } from './QuickStats'
 import type { Plant } from './types'
@@ -48,6 +49,15 @@ export default function HeroSection({
   const waterOverdue = isPast(nextWaterDue)
   const feedOverdue = isPast(nextFeedDate)
 
+  const nextWaterDate = new Date(`${nextWaterDue} ${new Date().getFullYear()}`)
+  const nextTaskText = `Needs water ${formatDistanceToNow(nextWaterDate, {
+    addSuffix: true,
+  })}${
+    plant.recommendedWaterMl !== undefined
+      ? ` (~${plant.recommendedWaterMl} ml)`
+      : ''
+  }`
+
   return (
     <section className="space-y-4">
       <div className="relative rounded-xl overflow-hidden shadow">
@@ -67,10 +77,11 @@ export default function HeroSection({
           </div>
         )}
         <div className="absolute inset-0 bg-black/30 flex flex-col justify-end p-4 sm:p-6">
-          <h1 className="text-3xl font-bold text-white drop-shadow-md">
-            {plant.nickname}
+          <h1 className="text-2xl font-semibold text-white drop-shadow-md">
+            {plant.nickname} ·{' '}
+            <span className="italic font-normal">{plant.species}</span>
           </h1>
-          <p className="italic text-gray-200">{plant.species}</p>
+          <p className="mt-1 text-sm text-gray-200">{nextTaskText}</p>
         </div>
       </div>
 
@@ -80,15 +91,23 @@ export default function HeroSection({
         <button
           onClick={onWater}
           aria-label="Water plant"
-          className={`flex items-center gap-1 px-4 py-2 rounded-full bg-blue-600 ${waterOverdue ? 'text-amber-600' : 'text-white'} transition-transform duration-150 hover:scale-105 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600`}
+          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
+            waterOverdue
+              ? 'bg-amber-100 text-amber-800'
+              : 'bg-blue-50 text-blue-700'
+          }`}
         >
           <Droplet className="h-4 w-4" />
-          {`Water (Due ${nextWaterDue})`}
+          {`Water (Due ${nextWaterDue}${plant.recommendedWaterMl !== undefined ? ` · ~${plant.recommendedWaterMl} ml` : ''})`}
         </button>
         <button
           onClick={onFertilize}
           aria-label="Fertilize plant"
-          className={`flex items-center gap-1 px-4 py-2 rounded-full bg-green-600 ${feedOverdue ? 'text-amber-600' : 'text-white'} transition-transform duration-150 hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:bg-green-500 dark:hover:bg-green-600`}
+          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
+            feedOverdue
+              ? 'bg-amber-100 text-amber-800'
+              : 'bg-green-50 text-green-700'
+          }`}
         >
           <Sprout className="h-4 w-4" />
           {`Fertilize (Due ${nextFeedDate})`}
@@ -96,7 +115,7 @@ export default function HeroSection({
         <button
           onClick={onAddNote}
           aria-label="Add note to plant"
-          className="flex items-center gap-1 px-4 py-2 rounded-full bg-purple-600 text-white transition-transform duration-150 hover:scale-105 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:bg-purple-500 dark:hover:bg-purple-600"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-purple-50 text-purple-700 text-sm transition-colors"
         >
           <FileText className="h-4 w-4" />
           Add Note

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import Sparkline from '@/components/Sparkline'
 import { Droplet, Sprout, Calendar, Activity } from 'lucide-react'
 import { calculateNutrientAvailability, calculateStressIndex } from '@/lib/plant-metrics'
+import type { ReactNode } from 'react'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 
@@ -23,75 +23,90 @@ export function calculateNextFeedDate(
 }
 
 export default function QuickStats({ plant, weather }: QuickStatsProps) {
+  const stress = Math.round(
+    calculateStressIndex({
+      overdueDays: plant.status === 'Water overdue' ? 1 : 0,
+      hydration: plant.hydration,
+      temperature: weather?.temperature ?? 25,
+      light: 50,
+    })
+  )
+
+  const row1 = [
+    { label: 'Last Watered', value: plant.lastWatered, icon: Droplet },
+    {
+      label: 'Next Water Due',
+      value: plant.nextDue,
+      icon: Calendar,
+      valueClass: 'text-blue-600',
+    },
+    {
+      label: 'Water Amount',
+      value:
+        plant.recommendedWaterMl !== undefined
+          ? `~${plant.recommendedWaterMl} ml`
+          : '—',
+      icon: Droplet,
+    },
+  ]
+
+  const row2 = [
+    { label: 'Last Fertilized', value: plant.lastFertilized, icon: Sprout },
+    {
+      label: 'Next Feed',
+      value: calculateNextFeedDate(
+        plant.lastFertilized,
+        plant.nutrientLevel ?? 100
+      ),
+      icon: Calendar,
+      valueClass: 'text-green-600',
+    },
+    {
+      label: 'Hydration / Stress',
+      value: `${plant.hydration}% / ${stress}`,
+      icon: Activity,
+      color: 'text-orange-600',
+    },
+  ]
+
+  function renderRow(
+    items: {
+      label: string
+      value: ReactNode
+      icon: any
+      valueClass?: string
+      color?: string
+    }[],
+  ) {
+    return (
+      <div className="flex divide-x divide-gray-200 dark:divide-gray-700 rounded-md overflow-hidden bg-gray-50 dark:bg-gray-800">
+        {items.map(({ label, value, icon: Icon, valueClass, color }) => (
+          <div key={label} className="flex-1 p-3 text-center">
+            <Icon
+              className={`mx-auto mb-1 h-4 w-4 text-gray-500 dark:text-gray-400 ${
+                color ?? ''
+              }`}
+            />
+            <div
+              className={`text-sm font-semibold ${
+                valueClass ?? 'text-gray-900 dark:text-white'
+              }`}
+            >
+              {value}
+            </div>
+            <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+              {label}
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
   return (
-    <section className="flex flex-wrap justify-between gap-4 md:gap-6">
-      {[
-        { label: 'Last Watered', value: plant.lastWatered, icon: Droplet },
-        {
-          label: 'Next Water Due',
-          value: (
-            <span className="flex items-center gap-1">
-              {plant.nextDue}
-              {plant.recommendedWaterMl !== undefined && (
-                <>
-                  <span>·</span>
-                  <span className="flex items-center">
-                    ~
-                    <span className="relative inline-flex items-center justify-center mx-1">
-                      <Droplet className="h-5 w-5 text-blue-500" />
-                      <span className="absolute text-[8px] font-bold text-blue-900">
-                        {plant.recommendedWaterMl}
-                      </span>
-                    </span>
-                    ml
-                  </span>
-                </>
-              )}
-            </span>
-          ),
-          icon: Calendar,
-        },
-        { label: 'Last Fertilized', value: plant.lastFertilized, icon: Sprout },
-        {
-          label: 'Next Feed',
-          value: calculateNextFeedDate(
-            plant.lastFertilized,
-            plant.nutrientLevel ?? 100
-          ),
-          icon: Calendar,
-        },
-        {
-          label: 'Hydration',
-          value: `${plant.hydration}%`,
-          icon: Droplet,
-          spark: plant.hydrationLog?.map((h) => h.value) ?? [],
-        },
-        {
-          label: 'Stress Score',
-          value: Math.round(
-            calculateStressIndex({
-              overdueDays: plant.status === 'Water overdue' ? 1 : 0,
-              hydration: plant.hydration,
-              temperature: weather?.temperature ?? 25,
-              light: 50,
-            })
-          ),
-          icon: Activity,
-          color: 'text-orange-600',
-        },
-      ].map(({ label, value, icon: Icon, spark, color }) => (
-        <div
-          key={label}
-          className="flex flex-col items-center justify-center gap-1 p-4 rounded-md bg-gray-50 dark:bg-gray-800 flex-1 min-w-[150px]"
-        >
-          <Icon className={`h-5 w-5 text-gray-500 dark:text-gray-400 ${color ?? ''}`} />
-          <span className="text-xl font-bold text-gray-900 dark:text-white">
-            {value}
-          </span>
-          <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
-          {spark && spark.length > 1 && <Sparkline data={spark} />}
-        </div>
-      ))}
+    <section className="space-y-2 text-sm">
+      {renderRow(row1)}
+      {renderRow(row2)}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- Overlay plant name, species, and next action atop hero image
- Compact quick stats into two-row strip with water amount and combined hydration/stress
- Soften care action buttons with pill styling and overdue tints; update test accordingly

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a099c8448324bc7dcbaa9893b1b6