### PR TITLE
Refine plant detail presentation

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -148,8 +148,7 @@ export function HydrationTrendChart({
         <Tooltip />
         <Legend />
         <ReferenceArea y1={0} y2={40} fill="#fecaca" fillOpacity={0.3} />
-        <ReferenceArea y1={40} y2={80} fill="#dcfce7" fillOpacity={0.3} />
-        <ReferenceArea y1={80} y2={100} fill="#fef9c3" fillOpacity={0.3} />
+        <ReferenceArea y1={40} y2={100} fill="#dcfce7" fillOpacity={0.3} />
         <Line
           type="monotone"
           dataKey="actual"
@@ -222,7 +221,7 @@ export function CareStreak({ events }: { events: CareEvent[] }) {
   })
 
   return (
-    <div className="grid grid-cols-6 gap-1 w-max" data-testid="care-streak">
+    <div className="grid grid-cols-7 gap-1 w-max" data-testid="care-streak">
       {days.map((d) => (
         <div
           key={d.date}
@@ -302,26 +301,39 @@ export function WaterBalanceChart({ data }: { data: WaterBalanceDatum[] }) {
 
 // Display a plant stress index as a radial gauge (0-100)
 export function StressIndexGauge({ value }: { value: number }) {
-  const data = [{ name: "Stress", value, fill: "#ef4444" }]
+  const data = [{ name: 'stress', value }]
   const { label, color } =
     value < 30
-      ? { label: "Low", color: "#22c55e" }
+      ? { label: 'Low', color: '#22c55e' }
       : value <= 70
-        ? { label: "Moderate", color: "#eab308" }
-        : { label: "High", color: "#ef4444" }
+        ? { label: 'Moderate', color: '#eab308' }
+        : { label: 'High', color: '#ef4444' }
   return (
     <ResponsiveContainer width="100%" height={250}>
       <RadialBarChart
         cx="50%"
         cy="50%"
-        innerRadius="80%"
+        innerRadius="70%"
         outerRadius="100%"
-        barSize={20}
+        barSize={14}
         data={data}
-        startAngle={180}
-        endAngle={0}
+        startAngle={90}
+        endAngle={-270}
       >
-        <RadialBar minAngle={15} background clockWise dataKey="value" />
+        <defs>
+          <linearGradient id="stressGradient" x1="0" y1="1" x2="1" y2="0">
+            <stop offset="0%" stopColor="#22c55e" />
+            <stop offset="50%" stopColor="#eab308" />
+            <stop offset="100%" stopColor="#ef4444" />
+          </linearGradient>
+        </defs>
+        <RadialBar
+          dataKey="value"
+          cornerRadius={8}
+          fill="url(#stressGradient)"
+          background
+          clockWise
+        />
         <text
           x="50%"
           y="50%"

--- a/components/plant-detail/Gallery.tsx
+++ b/components/plant-detail/Gallery.tsx
@@ -94,7 +94,7 @@ export default function Gallery({ photos = [], nickname }: GalleryProps) {
             </div>
           )}
 
-          <div>
+          <div className="relative">
             <button
               onClick={() => setOpenIndex(0)}
               className="focus:outline-none w-full h-64"
@@ -108,25 +108,32 @@ export default function Gallery({ photos = [], nickname }: GalleryProps) {
                 className="w-full h-64 object-cover rounded-lg"
                 loading="lazy"
               />
+              <span className="absolute bottom-1 left-1 rounded bg-black/50 px-1 text-xs text-white">
+                Photo 1
+              </span>
             </button>
             {length > 1 && (
               <div className="grid grid-cols-3 gap-4 mt-4">
                 {photos.slice(1).map((src, i) => (
-                  <button
-                    key={i + 1}
-                    onClick={() => setOpenIndex(i + 1)}
-                    className="focus:outline-none"
-                    aria-label={`View image ${i + 2} of ${length}`}
-                  >
-                    <Image
-                      src={src}
-                      alt={`${nickname} photo ${i + 2}`}
-                      width={400}
-                      height={400}
-                      className="w-full h-24 object-cover rounded-lg"
-                      loading="lazy"
-                    />
-                  </button>
+                  <div key={i + 1} className="relative">
+                    <button
+                      onClick={() => setOpenIndex(i + 1)}
+                      className="focus:outline-none"
+                      aria-label={`View image ${i + 2} of ${length}`}
+                    >
+                      <Image
+                        src={src}
+                        alt={`${nickname} photo ${i + 2}`}
+                        width={400}
+                        height={400}
+                        className="w-full h-24 object-cover rounded-lg"
+                        loading="lazy"
+                      />
+                      <span className="absolute bottom-1 left-1 rounded bg-black/50 px-1 text-xs text-white">
+                        Photo {i + 2}
+                      </span>
+                    </button>
+                  </div>
                 ))}
               </div>
             )}

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -60,7 +60,7 @@ export default function HeroSection({
 
   return (
     <section className="space-y-4">
-      <div className="relative rounded-xl overflow-hidden shadow">
+      <div className="relative rounded-xl overflow-hidden">
         {plant.photos && plant.photos.length > 0 ? (
           <Image
             src={plant.photos[0]}
@@ -77,45 +77,45 @@ export default function HeroSection({
           </div>
         )}
         <div className="absolute inset-0 bg-black/30 flex flex-col justify-end p-4 sm:p-6">
-          <h1 className="text-2xl font-semibold text-white drop-shadow-md">
+          <h1 className="text-2xl font-semibold text-white">
             {plant.nickname} ·{' '}
             <span className="italic font-normal">{plant.species}</span>
           </h1>
-          <p className="mt-1 text-sm text-gray-200">{nextTaskText}</p>
+          <p className="mt-1 text-lg font-medium text-white">{nextTaskText}</p>
         </div>
       </div>
 
       <QuickStats plant={plant} weather={weather} />
 
-      <div className="flex flex-wrap justify-center sm:justify-start gap-3">
+      <div className="flex flex-wrap justify-center sm:justify-start gap-2">
         <button
           onClick={onWater}
           aria-label="Water plant"
-          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
+          className={`flex items-center gap-1 px-3 py-1 rounded-full border text-sm ${
             waterOverdue
-              ? 'bg-amber-100 text-amber-800'
-              : 'bg-blue-50 text-blue-700'
+              ? 'bg-amber-50 text-blue-700 border-blue-300'
+              : 'bg-blue-50 text-blue-700 border-blue-200'
           }`}
         >
           <Droplet className="h-4 w-4" />
-          {`Water (Due ${nextWaterDue}${plant.recommendedWaterMl !== undefined ? ` · ~${plant.recommendedWaterMl} ml` : ''})`}
+          Water
         </button>
         <button
           onClick={onFertilize}
           aria-label="Fertilize plant"
-          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
+          className={`flex items-center gap-1 px-3 py-1 rounded-full border text-sm ${
             feedOverdue
-              ? 'bg-amber-100 text-amber-800'
-              : 'bg-green-50 text-green-700'
+              ? 'bg-amber-50 text-green-700 border-green-300'
+              : 'bg-green-50 text-green-700 border-green-200'
           }`}
         >
           <Sprout className="h-4 w-4" />
-          {`Fertilize (Due ${nextFeedDate})`}
+          Feed
         </button>
         <button
           onClick={onAddNote}
           aria-label="Add note to plant"
-          className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-purple-50 text-purple-700 text-sm transition-colors"
+          className="flex items-center gap-1 px-3 py-1 rounded-full border bg-purple-50 text-purple-700 text-sm border-purple-200"
         >
           <FileText className="h-4 w-4" />
           Add Note

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -1,8 +1,16 @@
 'use client'
 
-import { Droplet, Sprout, Calendar, Activity } from 'lucide-react'
-import { calculateNutrientAvailability, calculateStressIndex } from '@/lib/plant-metrics'
-import type { ReactNode } from 'react'
+import {
+  Droplet,
+  Sprout,
+  Calendar,
+  Activity,
+  Battery,
+} from 'lucide-react'
+import {
+  calculateNutrientAvailability,
+  calculateStressIndex,
+} from '@/lib/plant-metrics'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 
@@ -13,7 +21,7 @@ interface QuickStatsProps {
 
 export function calculateNextFeedDate(
   lastFertilized: string,
-  nutrientLevel: number
+  nutrientLevel: number,
 ) {
   const current = calculateNutrientAvailability(lastFertilized, nutrientLevel)
   const daysLeft = Math.max(0, Math.ceil((current - 30) / 2))
@@ -23,90 +31,63 @@ export function calculateNextFeedDate(
 }
 
 export default function QuickStats({ plant, weather }: QuickStatsProps) {
-  const stress = Math.round(
+  const stressValue = Math.round(
     calculateStressIndex({
       overdueDays: plant.status === 'Water overdue' ? 1 : 0,
       hydration: plant.hydration,
       temperature: weather?.temperature ?? 25,
       light: 50,
-    })
+    }),
   )
 
-  const row1 = [
-    { label: 'Last Watered', value: plant.lastWatered, icon: Droplet },
+  const stressLabel =
+    stressValue < 30
+      ? 'Low'
+      : stressValue <= 70
+        ? 'Moderate'
+        : 'High'
+
+  const stats = [
     {
-      label: 'Next Water Due',
-      value: plant.nextDue,
-      icon: Calendar,
-      valueClass: 'text-blue-600',
-    },
-    {
-      label: 'Water Amount',
-      value:
-        plant.recommendedWaterMl !== undefined
-          ? `~${plant.recommendedWaterMl} ml`
-          : '—',
       icon: Droplet,
+      text: `Last watered: ${plant.lastWatered}`,
     },
-  ]
-
-  const row2 = [
-    { label: 'Last Fertilized', value: plant.lastFertilized, icon: Sprout },
     {
-      label: 'Next Feed',
-      value: calculateNextFeedDate(
-        plant.lastFertilized,
-        plant.nutrientLevel ?? 100
-      ),
       icon: Calendar,
-      valueClass: 'text-green-600',
+      text: `Next water: ${plant.nextDue}${
+        plant.recommendedWaterMl !== undefined
+          ? ` (~${plant.recommendedWaterMl} ml)`
+          : ''
+      }`,
     },
     {
-      label: 'Hydration / Stress',
-      value: `${plant.hydration}% / ${stress}`,
+      icon: Sprout,
+      text: `Next feed: ${calculateNextFeedDate(
+        plant.lastFertilized,
+        plant.nutrientLevel ?? 100,
+      )}`,
+    },
+    {
+      icon: Battery,
+      text: `Hydration: ${plant.hydration}%`,
+    },
+    {
       icon: Activity,
-      color: 'text-orange-600',
+      text: `Stress: ${stressLabel} (${stressValue})`,
     },
   ]
-
-  function renderRow(
-    items: {
-      label: string
-      value: ReactNode
-      icon: any
-      valueClass?: string
-      color?: string
-    }[],
-  ) {
-    return (
-      <div className="flex divide-x divide-gray-200 dark:divide-gray-700 rounded-md overflow-hidden bg-gray-50 dark:bg-gray-800">
-        {items.map(({ label, value, icon: Icon, valueClass, color }) => (
-          <div key={label} className="flex-1 p-3 text-center">
-            <Icon
-              className={`mx-auto mb-1 h-4 w-4 text-gray-500 dark:text-gray-400 ${
-                color ?? ''
-              }`}
-            />
-            <div
-              className={`text-sm font-semibold ${
-                valueClass ?? 'text-gray-900 dark:text-white'
-              }`}
-            >
-              {value}
-            </div>
-            <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-              {label}
-            </div>
-          </div>
-        ))}
-      </div>
-    )
-  }
 
   return (
-    <section className="space-y-2 text-sm">
-      {renderRow(row1)}
-      {renderRow(row2)}
-    </section>
+    <ul className="flex flex-wrap gap-2 text-sm">
+      {stats.map(({ icon: Icon, text }) => (
+        <li
+          key={text}
+          className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 dark:bg-gray-800"
+        >
+          <Icon className="h-4 w-4" />
+          {text}
+        </li>
+      ))}
+    </ul>
   )
 }

--- a/components/plant-detail/Timeline.tsx
+++ b/components/plant-detail/Timeline.tsx
@@ -59,7 +59,13 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
             return (
               <div key={week}>
                 <h3 className="text-sm font-semibold mb-2">
-                  Week of {format(weekDate, 'MMM d')}
+                  {
+                    index === 0
+                      ? 'This week'
+                      : index === 1
+                        ? 'Last week'
+                        : `Week of ${format(weekDate, 'MMM d')}`
+                  }
                 </h3>
                 <ol className="relative border-l ml-4">
                   {weekEvents.map((e) => {


### PR DESCRIPTION
## Summary
- streamline plant detail header with prominent next action and compact stat pills
- simplify care buttons and streak display
- enrich analytics with hydration zones and gradient stress gauge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b68c9ec48324a57dd25080c8592b