### PR TITLE
Revamp plant detail layout

### DIFF
--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -72,7 +72,7 @@ describe('PlantDetailPage', () => {
     )
 
     expect(await screen.findByText(/Timeline/i)).toBeInTheDocument()
-    expect(screen.getAllByText(/Watered/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/ago/i).length).toBeGreaterThan(0)
   })
 
   it('falls back to sample data when offline', async () => {

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -220,10 +220,16 @@ export function CareStreak({ events }: { events: CareEvent[] }) {
     const d = new Date()
     d.setDate(today.getDate() - (29 - idx))
     const key = d.toISOString().split("T")[0]
-    const has = events.some(
-      (e) => new Date(e.date).toISOString().split("T")[0] === key
+    const hasWater = events.some(
+      (e) =>
+        e.type === "water" && new Date(e.date).toISOString().split("T")[0] === key
     )
-    return { date: key, has }
+    const hasFeed = events.some(
+      (e) =>
+        e.type === "fertilize" &&
+        new Date(e.date).toISOString().split("T")[0] === key
+    )
+    return { date: key, hasWater, hasFeed }
   })
 
   return (
@@ -231,11 +237,19 @@ export function CareStreak({ events }: { events: CareEvent[] }) {
       {days.map((d) => (
         <div
           key={d.date}
-          title={`${d.date}: ${d.has ? "care" : "no care"}`}
-          className={`w-3 h-3 rounded-full ${
-            d.has
-              ? "bg-green-500"
-              : "bg-gray-200 dark:bg-gray-700"
+          title={
+            d.hasWater || d.hasFeed
+              ? d.hasWater && d.hasFeed
+                ? `${d.date}: water & feed`
+                : `${d.date}: ${d.hasWater ? "water" : "feed"}`
+              : `${d.date}: no care`
+          }
+          className={`w-3 h-3 rounded ${
+            d.hasWater
+              ? "bg-blue-400"
+              : d.hasFeed
+                ? "bg-green-400"
+                : "bg-gray-200 dark:bg-gray-700"
           }`}
         />
       ))}

--- a/components/plant-detail/CareTrends.tsx
+++ b/components/plant-detail/CareTrends.tsx
@@ -14,7 +14,7 @@ interface CareTrendsProps {
 
 export default function CareTrends({ events }: CareTrendsProps) {
   return (
-    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800">
+    <section className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
       <div className="mb-4">
         <h2 className="text-lg font-semibold">Care Trends</h2>
       </div>

--- a/components/plant-detail/Gallery.tsx
+++ b/components/plant-detail/Gallery.tsx
@@ -45,7 +45,7 @@ export default function Gallery({ photos = [], nickname }: GalleryProps) {
   }, [openIndex, close, showNext, showPrev])
 
   return (
-    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800">
+    <section className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
       <h2 className="text-lg font-semibold mb-4">Gallery</h2>
       {length > 0 ? (
         <>
@@ -72,7 +72,7 @@ export default function Gallery({ photos = [], nickname }: GalleryProps) {
                 >
                   ×
                 </button>
-                  {length > 1 && (
+                {length > 1 && (
                   <>
                     <button
                       aria-label="Previous image"
@@ -94,49 +94,29 @@ export default function Gallery({ photos = [], nickname }: GalleryProps) {
             </div>
           )}
 
-          <div className="relative">
-            <button
-              onClick={() => setOpenIndex(0)}
-              className="focus:outline-none w-full h-64"
-              aria-label={`View image 1 of ${length}`}
-            >
-              <Image
-                src={photos[0]}
-                alt={`${nickname} photo 1`}
-                width={800}
-                height={600}
-                className="w-full h-64 object-cover rounded-lg"
-                loading="lazy"
-              />
-              <span className="absolute bottom-1 left-1 rounded bg-black/50 px-1 text-xs text-white">
-                Photo 1
-              </span>
-            </button>
-            {length > 1 && (
-              <div className="grid grid-cols-3 gap-4 mt-4">
-                {photos.slice(1).map((src, i) => (
-                  <div key={i + 1} className="relative">
-                    <button
-                      onClick={() => setOpenIndex(i + 1)}
-                      className="focus:outline-none"
-                      aria-label={`View image ${i + 2} of ${length}`}
-                    >
-                      <Image
-                        src={src}
-                        alt={`${nickname} photo ${i + 2}`}
-                        width={400}
-                        height={400}
-                        className="w-full h-24 object-cover rounded-lg"
-                        loading="lazy"
-                      />
-                      <span className="absolute bottom-1 left-1 rounded bg-black/50 px-1 text-xs text-white">
-                        Photo {i + 2}
-                      </span>
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
+          <div className="grid grid-cols-3 gap-4">
+            {photos.map((src, i) => (
+              <button
+                key={i}
+                onClick={() => setOpenIndex(i)}
+                className="group relative aspect-square w-full focus:outline-none"
+                aria-label={`View image ${i + 1} of ${length}`}
+              >
+                <Image
+                  src={src}
+                  alt={`${nickname} photo ${i + 1}`}
+                  fill
+                  sizes="200px"
+                  className="object-cover rounded-lg"
+                  loading="lazy"
+                />
+                <span className="absolute inset-0 flex items-end justify-start rounded-lg bg-black/0 hover:bg-black/40 transition-colors">
+                  <span className="m-1 rounded px-1 text-xs text-white opacity-0 group-hover:opacity-100">
+                    Photo {i + 1}
+                  </span>
+                </span>
+              </button>
+            ))}
           </div>
         </>
       ) : (

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -5,7 +5,7 @@ import { Droplet, Sprout, FileText } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { getHydrationProgress } from '@/components/PlantCard'
-import QuickStats, { calculateNextFeedDate } from './QuickStats'
+import QuickStats from './QuickStats'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 
@@ -26,28 +26,11 @@ export default function HeroSection({
 }: HeroSectionProps) {
   const progress = getHydrationProgress(plant.hydration)
   const [nextWaterDue, setNextWaterDue] = useState(plant.nextDue)
-  const [nextFeedDate, setNextFeedDate] = useState(
-    calculateNextFeedDate(plant.lastFertilized, plant.nutrientLevel ?? 100)
-  )
 
   useEffect(() => {
     setNextWaterDue(plant.nextDue)
   }, [plant.nextDue])
 
-  useEffect(() => {
-    setNextFeedDate(
-      calculateNextFeedDate(plant.lastFertilized, plant.nutrientLevel ?? 100)
-    )
-  }, [plant.lastFertilized, plant.nutrientLevel])
-
-  function isPast(dateStr: string) {
-    const year = new Date().getFullYear()
-    const date = new Date(`${dateStr} ${year}`)
-    return date < new Date()
-  }
-
-  const waterOverdue = isPast(nextWaterDue)
-  const feedOverdue = isPast(nextFeedDate)
 
   const nextWaterDate = new Date(`${nextWaterDue} ${new Date().getFullYear()}`)
   const nextTaskText = `Needs water ${formatDistanceToNow(nextWaterDate, {
@@ -59,43 +42,36 @@ export default function HeroSection({
   }`
 
   return (
-    <section className="space-y-4">
-      <div className="relative rounded-xl overflow-hidden">
+    <section className="space-y-6">
+      <div className="relative h-64 sm:h-80 rounded-xl overflow-hidden">
         {plant.photos && plant.photos.length > 0 ? (
           <Image
             src={plant.photos[0]}
             alt={plant.nickname}
-            width={1200}
-            height={800}
+            fill
             sizes="100vw"
-            className="w-full h-64 sm:h-80 object-cover"
+            className="object-cover"
             loading="lazy"
           />
         ) : (
-          <div className="w-full h-64 sm:h-80 flex items-center justify-center bg-gray-100 dark:bg-gray-800">
+          <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">
             <span className="text-gray-500 dark:text-gray-400">No photo</span>
           </div>
         )}
-        <div className="absolute inset-0 bg-black/30 flex flex-col justify-end p-4 sm:p-6">
-          <h1 className="text-2xl font-semibold text-white">
-            {plant.nickname} ·{' '}
-            <span className="italic font-normal">{plant.species}</span>
-          </h1>
-          <p className="mt-1 text-lg font-medium text-white">{nextTaskText}</p>
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 via-black/0 p-4 sm:p-6">
+          <h1 className="text-3xl font-serif text-white">{plant.nickname}</h1>
+          <p className="text-lg italic text-white/80">{plant.species}</p>
+          <p className="mt-2 text-base text-white/90">{nextTaskText}</p>
         </div>
       </div>
 
       <QuickStats plant={plant} weather={weather} />
 
-      <div className="flex flex-wrap justify-center sm:justify-start gap-2">
+      <div className="flex flex-wrap justify-center sm:justify-start gap-3">
         <button
           onClick={onWater}
           aria-label="Water plant"
-          className={`flex items-center gap-1 px-3 py-1 rounded-full border text-sm ${
-            waterOverdue
-              ? 'bg-amber-50 text-blue-700 border-blue-300'
-              : 'bg-blue-50 text-blue-700 border-blue-200'
-          }`}
+          className="flex items-center gap-1 px-4 py-1 rounded-full border border-blue-300 text-sm text-blue-700 bg-white/30 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400"
         >
           <Droplet className="h-4 w-4" />
           Water
@@ -103,11 +79,7 @@ export default function HeroSection({
         <button
           onClick={onFertilize}
           aria-label="Fertilize plant"
-          className={`flex items-center gap-1 px-3 py-1 rounded-full border text-sm ${
-            feedOverdue
-              ? 'bg-amber-50 text-green-700 border-green-300'
-              : 'bg-green-50 text-green-700 border-green-200'
-          }`}
+          className="flex items-center gap-1 px-4 py-1 rounded-full border border-green-300 text-sm text-green-700 bg-white/30 hover:bg-green-50 dark:border-green-400 dark:text-green-400"
         >
           <Sprout className="h-4 w-4" />
           Feed
@@ -115,7 +87,7 @@ export default function HeroSection({
         <button
           onClick={onAddNote}
           aria-label="Add note to plant"
-          className="flex items-center gap-1 px-3 py-1 rounded-full border bg-purple-50 text-purple-700 text-sm border-purple-200"
+          className="flex items-center gap-1 px-4 py-1 rounded-full border border-purple-300 text-sm text-purple-700 bg-white/30 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-400"
         >
           <FileText className="h-4 w-4" />
           Add Note

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -50,11 +50,11 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
   const stats = [
     {
       icon: Droplet,
-      text: `Last watered: ${plant.lastWatered}`,
+      text: `${plant.lastWatered} (Last watered)`,
     },
     {
       icon: Calendar,
-      text: `Next water: ${plant.nextDue}${
+      text: `${plant.nextDue}${
         plant.recommendedWaterMl !== undefined
           ? ` (~${plant.recommendedWaterMl} ml)`
           : ''
@@ -62,27 +62,27 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
     },
     {
       icon: Sprout,
-      text: `Next feed: ${calculateNextFeedDate(
+      text: `${calculateNextFeedDate(
         plant.lastFertilized,
         plant.nutrientLevel ?? 100,
-      )}`,
+      )} (Next feed)`,
     },
     {
       icon: Battery,
-      text: `Hydration: ${plant.hydration}%`,
+      text: `${plant.hydration}% Hydration`,
     },
     {
       icon: Activity,
-      text: `Stress: ${stressLabel} (${stressValue})`,
+      text: `${stressLabel} Stress`,
     },
   ]
 
   return (
-    <ul className="flex flex-wrap gap-2 text-sm">
+    <ul className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-700 dark:text-gray-200">
       {stats.map(({ icon: Icon, text }) => (
         <li
           key={text}
-          className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 dark:bg-gray-800"
+          className="flex items-center gap-1 after:content-['|'] last:after:content-[''] after:mx-2 after:text-gray-300"
         >
           <Icon className="h-4 w-4" />
           {text}

--- a/components/plant-detail/Timeline.tsx
+++ b/components/plant-detail/Timeline.tsx
@@ -7,18 +7,12 @@ import type { PlantEvent } from './types'
 
 const EVENT_TYPES = {
   water: {
-    label: 'Watered',
-    color: 'bg-blue-100 text-blue-700',
     icon: Droplet,
   },
   fertilize: {
-    label: 'Fertilized',
-    color: 'bg-green-100 text-green-700',
     icon: Sprout,
   },
   note: {
-    label: 'Note',
-    color: 'bg-purple-100 text-purple-700',
     icon: FileText,
   },
 } as const
@@ -45,7 +39,7 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
     : []
 
   return (
-    <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800 space-y-4">
+    <section className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800 space-y-4">
       <h2 className="text-lg font-semibold">Timeline</h2>
       {!weeks.length ? (
         <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -83,16 +77,15 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
                           onClick={() => setExpandedId(open ? null : e.id)}
                           className="text-left w-full"
                         >
-                          <time className="block text-xs text-gray-500">
+                          <time className="text-sm text-gray-700 dark:text-gray-300">
                             {formatDistanceToNow(new Date(e.date), {
                               addSuffix: true,
                             })}
                           </time>
-                          <span className="font-medium">{type.label}</span>
                         </button>
-                        {open && (
+                        {open && e.type === 'note' && (
                           <div className="mt-2 p-3 rounded-lg bg-gray-50 dark:bg-gray-800 text-sm">
-                            {e.type === 'note' && e.note}
+                            {e.note}
                           </div>
                         )}
                       </li>


### PR DESCRIPTION
## Summary
- soften hero section with gradient background image and outline action chips
- streamline quick stats into minimalist icon strip
- color-code care streak and simplify timeline and gallery visuals

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5bb84211483248f924de760992c89