### PR TITLE
Fix hydration progress bar class usage

### DIFF
--- a/components/__tests__/HeroSection.test.tsx
+++ b/components/__tests__/HeroSection.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import HeroSection from '../plant-detail/HeroSection'
+import type { Plant } from '../plant-detail/types'
+
+const basePlant: Plant = {
+  nickname: 'Fern',
+  species: 'Pteridophyta',
+  status: 'Healthy',
+  hydration: 0,
+  hydrationLog: [],
+  lastWatered: 'Jan 1',
+  nextDue: 'Jan 2',
+  lastFertilized: 'Jan 1',
+  potSize: 10,
+  recommendedWaterMl: 100,
+  nutrientLevel: 80,
+  events: [],
+  photos: [],
+}
+
+function renderHero(hydration: number) {
+  render(
+    <HeroSection
+      plant={{ ...basePlant, hydration }}
+      weather={null}
+      onWater={() => {}}
+      onFertilize={() => {}}
+      onAddNote={() => {}}
+    />,
+  )
+}
+
+describe('HeroSection hydration bar', () => {
+  it('uses fertilize to water gradient when hydration is at least 60', () => {
+    renderHero(60)
+    const progress = screen.getByRole('progressbar', { name: /hydration/i })
+    const bar = progress.querySelector('div') as HTMLElement
+    expect(bar).toHaveClass('from-fertilize')
+    expect(bar).toHaveClass('to-water')
+    expect(progress).toHaveAttribute('aria-valuenow', '60')
+    expect(progress).toHaveAttribute('aria-valuetext', '60% hydration')
+  })
+
+  it('uses alert gradient when hydration is below 60', () => {
+    renderHero(59)
+    const progress = screen.getByRole('progressbar', { name: /hydration/i })
+    const bar = progress.querySelector('div') as HTMLElement
+    expect(bar).toHaveClass('from-alert')
+    expect(bar).toHaveClass('to-alert-red')
+  })
+})

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -108,7 +108,7 @@ export default function HeroSection({
         aria-valuetext={`${progress.pct}% hydration`}
       >
         <div
-          className={`h-2 rounded-full ${progress.barColor}`}
+          className={`h-2 rounded-full ${progress.barClass}`}
           style={{ width: `${progress.pct}%` }}
         />
         <span className="sr-only">{`${progress.pct}% hydration`}</span>


### PR DESCRIPTION
## Summary
- use `barClass` from `getHydrationProgress` in plant detail hydration bar
- add tests for HeroSection hydration progress gradient and accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5bdef52e8832487751576305cd8db