### PR TITLE
feat: link comparative charts to plant detail

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import dynamic from "next/dynamic"
+import { useRouter, useSearchParams } from "next/navigation"
 
 const TempHumidityChart = dynamic(
   () => import("@/components/Charts").then((m) => m.TempHumidityChart),
@@ -126,7 +127,12 @@ export default function SciencePanel() {
   const stressData = stressTrend(stressReadings)
   const currentStress = stressData[stressData.length - 1]?.stress ?? 0
 
-  const plants = Object.values(samplePlants)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const plants = Object.entries(samplePlants).map(([id, plant]) => ({
+    id,
+    ...plant,
+  }))
   const comparisonData = collectPlantMetrics(plants)
 
   const taskEvents: CareEvent[] = [
@@ -139,6 +145,11 @@ export default function SciencePanel() {
   ]
 
   const toggleUnit = () => setTempUnit((u) => (u === "F" ? "C" : "F"))
+
+  const handleSelect = (id: string) => {
+    const query = searchParams.toString()
+    router.push(`/plants/${id}${query ? `?${query}` : ""}`)
+  }
 
   return (
     <main className="flex-1 p-4 md:p-6">
@@ -199,7 +210,23 @@ export default function SciencePanel() {
       </section>
 
       <section className="mt-4 md:mt-6">
-        <h3 className="font-medium text-gray-800">Plant Comparison</h3>
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-gray-800">Plant Comparison</h3>
+          <select
+            onChange={(e) => handleSelect(e.target.value)}
+            className="border rounded px-2 py-1"
+            defaultValue=""
+          >
+            <option value="" disabled>
+              View plant...
+            </option>
+            {plants.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.nickname}
+              </option>
+            ))}
+          </select>
+        </div>
         <ComparativeChart plants={plants} data={comparisonData} />
       </section>
 

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/lib/plant-metrics"
 import type { Plant } from "@/lib/plants"
 import type { Weather } from "@/lib/weather"
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
 
 
 // Dummy dataset for environment over 7 days
@@ -177,7 +179,7 @@ export function ComparativeChart({
   plants,
   data,
 }: {
-  plants: Plant[]
+  plants: (Plant & { id: string })[]
   data: ComparativeDatum[]
 }) {
   const colors = [
@@ -191,6 +193,29 @@ export function ComparativeChart({
     "#fde047",
   ]
 
+  const searchParams = useSearchParams()
+  const query = Object.fromEntries(searchParams.entries())
+
+  const renderLegend = ({ payload }: any) => (
+    <ul className="flex flex-wrap gap-4">
+      {payload?.map((entry: any) => {
+        const plant = plants.find((p) => p.nickname === entry.value)
+        if (!plant) return null
+        return (
+          <li key={plant.id} className="flex items-center">
+            <span
+              className="w-3 h-3 mr-1"
+              style={{ backgroundColor: entry.color }}
+            />
+            <Link href={{ pathname: `/plants/${plant.id}`, query }}>
+              {entry.value}
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+
   return (
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
@@ -198,7 +223,7 @@ export function ComparativeChart({
         <XAxis dataKey="date" />
         <YAxis domain={[0, 100]} />
         <Tooltip />
-        <Legend />
+        <Legend content={renderLegend} />
         {plants.map((p, idx) => (
           <Line
             key={p.nickname}

--- a/components/__tests__/ComparativeChart.test.tsx
+++ b/components/__tests__/ComparativeChart.test.tsx
@@ -3,6 +3,10 @@ import { ComparativeChart } from '../Charts'
 import { collectPlantMetrics } from '@/lib/plant-metrics'
 import { samplePlants } from '@/lib/plants'
 
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}))
+
 jest.mock('recharts', () => {
   const original = jest.requireActual('recharts')
   const React = require('react')
@@ -18,7 +22,10 @@ jest.mock('recharts', () => {
 
 describe('ComparativeChart', () => {
   it('renders a line for each plant', () => {
-    const plants = [samplePlants['1'], samplePlants['2']]
+    const plants = [
+      { id: '1', ...samplePlants['1'] },
+      { id: '2', ...samplePlants['2'] },
+    ]
     const data = collectPlantMetrics(plants)
     render(<ComparativeChart plants={plants} data={data} />)
     const lines = screen.getAllByTestId(/comparative-line-/)


### PR DESCRIPTION
## Summary
- link plant comparison legend items to each plant's detail page, preserving query params
- add plant selector to science panel for quick navigation to individual plants

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5be14e7ec83248ac764a2e692b3ad