### PR TITLE
Add subtle ripple effect to plant action buttons

### DIFF
--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -71,24 +71,27 @@ export default function HeroSection({
         <button
           onClick={onWater}
           aria-label="Water plant"
-          className="flex items-center gap-1 px-4 py-1 rounded-full border border-blue-300 text-sm text-blue-700 bg-white/30 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400"
+          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-blue-300 text-sm text-blue-700 bg-white/30 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400 transition-colors"
         >
+          <span className="pointer-events-none absolute inset-0 rounded-full bg-blue-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
           <Droplet className="h-4 w-4" />
           Water
         </button>
         <button
           onClick={onFertilize}
           aria-label="Fertilize plant"
-          className="flex items-center gap-1 px-4 py-1 rounded-full border border-green-300 text-sm text-green-700 bg-white/30 hover:bg-green-50 dark:border-green-400 dark:text-green-400"
+          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-green-300 text-sm text-green-700 bg-white/30 hover:bg-green-50 dark:border-green-400 dark:text-green-400 transition-colors"
         >
+          <span className="pointer-events-none absolute inset-0 rounded-full bg-green-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
           <Sprout className="h-4 w-4" />
           Feed
         </button>
         <button
           onClick={onAddNote}
           aria-label="Add note to plant"
-          className="flex items-center gap-1 px-4 py-1 rounded-full border border-purple-300 text-sm text-purple-700 bg-white/30 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-400"
+          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-purple-300 text-sm text-purple-700 bg-white/30 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-400 transition-colors"
         >
+          <span className="pointer-events-none absolute inset-0 rounded-full bg-purple-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
           <FileText className="h-4 w-4" />
           Add Note
         </button>


### PR DESCRIPTION
## Summary
- enhance hero section action buttons with a gentle ripple animation on hover or focus

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5bfeb9c908324b95f5f621dafa908