### PR TITLE
Enable swipeable chart cards

### DIFF
--- a/components/ChartCard.tsx
+++ b/components/ChartCard.tsx
@@ -10,7 +10,7 @@ interface ChartCardProps {
 
 export default function ChartCard({ title, insight, children }: ChartCardProps) {
   return (
-    <div className="flex-shrink-0 min-w-full md:min-w-0 rounded-lg bg-white dark:bg-gray-900 p-4 shadow-sm">
+    <div className="flex-shrink-0 min-w-full md:min-w-0 snap-start rounded-lg bg-white dark:bg-gray-900 p-4 shadow-sm">
       <h4 className="font-semibold mb-2 text-gray-900 dark:text-gray-100">{title}</h4>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{insight}</p>
       {children}

--- a/components/plant-detail/EnvironmentBlock.tsx
+++ b/components/plant-detail/EnvironmentBlock.tsx
@@ -36,7 +36,7 @@ export default function EnvironmentBlock({ env, envChartData }: EnvironmentBlock
         Temperature, humidity, and vapor pressure deficit readings.
       </p>
       <EnvRow temperature={env.temperature} humidity={env.humidity} vpd={env.vpd} tempUnit="C" />
-      <div className="mt-4 flex gap-6 overflow-x-auto md:flex-col md:overflow-visible">
+      <div className="mt-4 flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
         <ChartCard title="Temperature & Humidity" insight="Daily temperature and humidity readings.">
           <TempHumidityChart tempUnit="C" data={envChartData} />
         </ChartCard>

--- a/components/plant-detail/HydrationBlock.tsx
+++ b/components/plant-detail/HydrationBlock.tsx
@@ -47,7 +47,7 @@ export default function HydrationBlock({
       <p className="text-sm text-gray-500 mb-4">
         Hydration history and nutrient levels.
       </p>
-      <div className="flex gap-6 overflow-x-auto md:flex-col md:overflow-visible">
+      <div className="flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
         <ChartCard title="Nutrient Levels" insight="Nutrient availability over time">
           <NutrientLevelChart
             lastFertilized={plant.lastFertilized}
@@ -58,7 +58,7 @@ export default function HydrationBlock({
           <HydrationTrendChart log={plant.hydrationLog ?? []} />
         </ChartCard>
       </div>
-      <div className="mt-4 flex overflow-x-auto md:flex-col md:overflow-visible">
+      <div className="mt-4 flex overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
         <ChartCard title="Water Balance" insight="Water balance with ET0">
           <div className="mb-2 flex items-center gap-2">
             <div className="flex gap-1">

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -32,7 +32,7 @@ export default function StressBlock({ plant, weather, stressData }: StressBlockP
       <p className="text-sm text-gray-500 mb-4">
         Stress index overview and overall health radar.
       </p>
-      <div className="flex gap-6 overflow-x-auto md:flex-col md:overflow-visible">
+      <div className="flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
         <ChartCard title="Stress Index" insight="Current plant stress level">
           <StressIndexGauge
             value={calculateStressIndex({
@@ -54,7 +54,7 @@ export default function StressBlock({ plant, weather, stressData }: StressBlockP
           />
         </ChartCard>
       </div>
-      <div className="mt-4 flex overflow-x-auto md:flex-col md:overflow-visible">
+      <div className="mt-4 flex overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
         <ChartCard title="Stress Trend" insight="Stress index over time">
           <StressIndexChart data={stressData} />
         </ChartCard>


### PR DESCRIPTION
## Summary
- add `snap-x` scrolling to plant detail chart containers
- ensure `ChartCard` snaps and occupies full width for mobile

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c87940ec832497df74191fced33f