### PR TITLE
Replace emojis with icons on plant detail page

### DIFF
--- a/components/plant-detail/EnvironmentBlock.tsx
+++ b/components/plant-detail/EnvironmentBlock.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { Thermometer } from 'lucide-react'
 import EnvRow from '@/components/EnvRow'
 import ChartCard from '@/components/ChartCard'
 
@@ -31,7 +32,10 @@ interface EnvironmentBlockProps {
 export default function EnvironmentBlock({ env, envChartData }: EnvironmentBlockProps) {
   return (
     <details id="environment" open>
-      <summary className="text-lg font-semibold cursor-pointer"><span className="mr-1">🌡</span>Environment</summary>
+      <summary className="text-lg font-semibold cursor-pointer">
+        <Thermometer className="inline-block w-4 h-4 mr-1" />
+        Environment
+      </summary>
       <p className="text-sm text-gray-500 mb-4">
         Temperature, humidity, and vapor pressure deficit readings.
       </p>

--- a/components/plant-detail/HydrationBlock.tsx
+++ b/components/plant-detail/HydrationBlock.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { Droplet } from 'lucide-react'
 import ChartCard from '@/components/ChartCard'
 import type { Plant } from './types'
 import type { WaterBalanceDatum } from '@/lib/plant-metrics'
@@ -43,7 +44,10 @@ export default function HydrationBlock({
 }: HydrationBlockProps) {
   return (
     <details id="hydration" open>
-      <summary className="text-lg font-semibold cursor-pointer"><span className="mr-1">💧</span>Hydration & Nutrients</summary>
+      <summary className="text-lg font-semibold cursor-pointer">
+        <Droplet className="inline-block w-4 h-4 mr-1" />
+        Hydration & Nutrients
+      </summary>
       <p className="text-sm text-gray-500 mb-4">
         Hydration history and nutrient levels.
       </p>


### PR DESCRIPTION
## Summary
- use lucide icons in environment section instead of thermometer emoji
- replace hydration emoji with droplet icon

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c90588348324a5782b61cb76e154