### PR TITLE
Add VPD gauge axis with contextual ticks and tests

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -119,6 +119,7 @@ export function TempHumidityChart({
 }
 
 export function VPDGauge({ value = 1.2 }: { value?: number }) {
+  const max = 3
   const data = [{ name: "VPD", value, fill: "#4CAF50" }]
   return (
     <ResponsiveContainer width="100%" height={250}>
@@ -132,11 +133,30 @@ export function VPDGauge({ value = 1.2 }: { value?: number }) {
         startAngle={180}
         endAngle={0}
       >
+        <PolarAngleAxis
+          type="number"
+          domain={[0, max]}
+          ticks={[0, 1.2, max]}
+          tick={({ x, y, payload }: any) => (
+            <text
+              x={x}
+              y={y}
+              textAnchor="middle"
+              fill="#6b7280"
+              fontSize={10}
+            >
+              {payload.value}
+            </text>
+          )}
+          tickLine={false}
+        />
         <RadialBar
           minAngle={15}
           background
           clockWise
           dataKey="value"
+          data-testid="vpd-bar"
+          isAnimationActive={false}
         />
         <text
           x="50%"

--- a/components/__tests__/VPDGauge.test.tsx
+++ b/components/__tests__/VPDGauge.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { VPDGauge } from '../Charts'
+
+jest.mock('recharts', () => {
+  const original = jest.requireActual('recharts')
+  const React = require('react')
+  return {
+    ...original,
+    ResponsiveContainer: ({ children }: any) => (
+      <div style={{ width: 400, height: 300 }}>
+        {React.cloneElement(children, { width: 400, height: 300 })}
+      </div>
+    ),
+  }
+})
+
+describe('VPDGauge', () => {
+  it('changes arc length when value changes', () => {
+    const { rerender, getByTestId } = render(<VPDGauge value={0.5} />)
+    const d1 = getByTestId('vpd-bar').getAttribute('d')
+    rerender(<VPDGauge value={2} />)
+    const d2 = getByTestId('vpd-bar').getAttribute('d')
+    expect(d1).not.toBe(d2)
+  })
+})


### PR DESCRIPTION
## Summary
- introduce PolarAngleAxis with 0–3 kPa domain and tick labels to VPDGauge
- expose radial bar for testing and disable animation
- add unit test verifying gauge arc length responds to value changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c952441c83249a3b898a6811af7f