### PR TITLE
feat: add plant care plan section

### DIFF
--- a/app/(dashboard)/plants/__tests__/page.test.tsx
+++ b/app/(dashboard)/plants/__tests__/page.test.tsx
@@ -23,19 +23,25 @@ describe('PlantDetailPage', () => {
   })
 
   it('shows placeholder when plant has no photos', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        nickname: 'Test',
-        species: 'Species',
-        status: 'Fine',
-        hydration: 50,
-        lastWatered: 'Aug 1',
-        nextDue: 'Aug 5',
-        events: [],
-        // no photos
-      }),
-    }) as any
+    const mock = jest.fn().mockImplementation((url: any) => {
+      if (url.toString().includes('/care-plan')) {
+        return Promise.resolve({ ok: true, text: async () => '' })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          nickname: 'Test',
+          species: 'Species',
+          status: 'Fine',
+          hydration: 50,
+          lastWatered: 'Aug 1',
+          nextDue: 'Aug 5',
+          events: [],
+          // no photos
+        }),
+      })
+    })
+    global.fetch = mock as any
 
     render(
       <ToastProvider>
@@ -47,19 +53,25 @@ describe('PlantDetailPage', () => {
   })
 
   it('handles null events without crashing', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        nickname: 'Test',
-        species: 'Species',
-        status: 'Fine',
-        hydration: 50,
-        lastWatered: 'Aug 1',
-        nextDue: 'Aug 5',
-        events: [null, { id: 1, type: 'water', date: 'Aug 1' }],
-        photos: [],
-      }),
-    }) as any
+    const mock = jest.fn().mockImplementation((url: any) => {
+      if (url.toString().includes('/care-plan')) {
+        return Promise.resolve({ ok: true, text: async () => '' })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          nickname: 'Test',
+          species: 'Species',
+          status: 'Fine',
+          hydration: 50,
+          lastWatered: 'Aug 1',
+          nextDue: 'Aug 5',
+          events: [null, { id: 1, type: 'water', date: 'Aug 1' }],
+          photos: [],
+        }),
+      })
+    })
+    global.fetch = mock as any
 
     render(
       <ToastProvider>
@@ -102,10 +114,17 @@ describe('PlantDetailPage', () => {
       photos: [],
     }
 
-    const mockFetch = jest
-      .fn()
-      .mockResolvedValueOnce({ ok: false, status: 500 })
-      .mockResolvedValueOnce({ ok: true, json: async () => plant })
+    let plantCall = 0
+    const mockFetch = jest.fn().mockImplementation((url: any) => {
+      if (url.toString().includes('/care-plan')) {
+        return Promise.resolve({ ok: true, text: async () => '' })
+      }
+      plantCall++
+      if (plantCall === 1) {
+        return Promise.resolve({ ok: false, status: 500 })
+      }
+      return Promise.resolve({ ok: true, json: async () => plant })
+    })
     global.fetch = mockFetch as any
     const user = userEvent.setup()
 
@@ -134,10 +153,13 @@ describe('PlantDetailPage', () => {
       photos: [],
     }
 
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => plant,
-    }) as any
+    const mock = jest.fn().mockImplementation((url: any) => {
+      if (url.toString().includes('/care-plan')) {
+        return Promise.resolve({ ok: true, text: async () => '' })
+      }
+      return Promise.resolve({ ok: true, json: async () => plant })
+    })
+    global.fetch = mock as any
 
     const user = userEvent.setup()
 
@@ -170,10 +192,13 @@ describe('PlantDetailPage', () => {
       photos: [],
     }
 
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => plant,
-    }) as any
+    const mock = jest.fn().mockImplementation((url: any) => {
+      if (url.toString().includes('/care-plan')) {
+        return Promise.resolve({ ok: true, text: async () => '' })
+      }
+      return Promise.resolve({ ok: true, json: async () => plant })
+    })
+    global.fetch = mock as any
 
     const user = userEvent.setup()
 
@@ -206,10 +231,13 @@ describe('PlantDetailPage', () => {
       photos: [],
     }
 
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => plant,
-    }) as any
+    const mock = jest.fn().mockImplementation((url: any) => {
+      if (url.toString().includes('/care-plan')) {
+        return Promise.resolve({ ok: true, text: async () => '' })
+      }
+      return Promise.resolve({ ok: true, json: async () => plant })
+    })
+    global.fetch = mock as any
 
     const user = userEvent.setup()
 

--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import CarePlan from '../plant-detail/CarePlan'
+
+describe('CarePlan', () => {
+  it('shows placeholder when plan is empty', () => {
+    render(<CarePlan plan={''} />)
+    expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
+  })
+
+  it('renders provided plan text', () => {
+    render(<CarePlan plan={'Water daily'} />)
+    expect(screen.getByText(/Water daily/i)).toBeInTheDocument()
+  })
+})

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+interface CarePlanProps {
+  plan?: string | null
+}
+
+export default function CarePlan({ plan }: CarePlanProps) {
+  const content = plan && plan.trim() ? plan : 'No care plan available'
+  return (
+    <section className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
+      <h2 className="text-lg font-semibold mb-4">Care Plan</h2>
+      <pre className="whitespace-pre-line text-sm">{content}</pre>
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Summary
- fetch and display per-plant care plan on detail page
- add CarePlan component with placeholder text
- test care plan rendering and update existing page tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ca85560c8324815d031db0ba550f