### PR TITLE
Remove icons from plant detail headings

### DIFF
--- a/components/plant-detail/EnvironmentBlock.tsx
+++ b/components/plant-detail/EnvironmentBlock.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { Thermometer } from 'lucide-react'
 import EnvRow from '@/components/EnvRow'
 import ChartCard from '@/components/ChartCard'
 
@@ -32,10 +31,7 @@ interface EnvironmentBlockProps {
 export default function EnvironmentBlock({ env, envChartData }: EnvironmentBlockProps) {
   return (
     <details id="environment" open>
-      <summary className="text-lg font-semibold cursor-pointer">
-        <Thermometer className="inline-block w-4 h-4 mr-1" />
-        Environment
-      </summary>
+      <summary className="text-lg font-semibold cursor-pointer">Environment</summary>
       <p className="text-sm text-gray-500 mb-4">
         Temperature, humidity, and vapor pressure deficit readings.
       </p>

--- a/components/plant-detail/HydrationBlock.tsx
+++ b/components/plant-detail/HydrationBlock.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { Droplet } from 'lucide-react'
 import ChartCard from '@/components/ChartCard'
 import type { Plant } from './types'
 import type { WaterBalanceDatum } from '@/lib/plant-metrics'
@@ -44,10 +43,7 @@ export default function HydrationBlock({
 }: HydrationBlockProps) {
   return (
     <details id="hydration" open>
-      <summary className="text-lg font-semibold cursor-pointer">
-        <Droplet className="inline-block w-4 h-4 mr-1" />
-        Hydration & Nutrients
-      </summary>
+      <summary className="text-lg font-semibold cursor-pointer">Hydration & Nutrients</summary>
       <p className="text-sm text-gray-500 mb-4">
         Hydration history and nutrient levels.
       </p>

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -28,7 +28,7 @@ interface StressBlockProps {
 export default function StressBlock({ plant, weather, stressData }: StressBlockProps) {
   return (
     <details id="plant-health" open>
-      <summary className="text-lg font-semibold cursor-pointer"><span className="mr-1">⚡</span>Plant Health</summary>
+      <summary className="text-lg font-semibold cursor-pointer">Plant Health</summary>
       <p className="text-sm text-gray-500 mb-4">
         Stress index overview and overall health radar.
       </p>


### PR DESCRIPTION
## Summary
- drop Thermometer icon from Environment section heading
- remove Droplet icon from Hydration & Nutrients heading
- strip lightning emoji from Plant Health heading

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cb0b712483248d638e4e55d132cb