### PR TITLE
Improve care plan placement and styling

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -277,20 +277,20 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               onAddNote={handleAddNote}
             />
             <div className="mt-8">
-              <AnalyticsPanel plant={plant} weather={weather} />
-            </div>
-            <div className="mt-8">
               {carePlanLoading ? (
-                <div className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800 text-center text-sm text-gray-500">
+                <div className="rounded-xl p-6 bg-green-50 dark:bg-gray-800 text-center text-sm text-gray-500">
                   Loading care plan...
                 </div>
               ) : carePlanError ? (
-                <div className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800 text-sm text-red-500">
+                <div className="rounded-xl p-6 bg-green-50 dark:bg-gray-800 text-sm text-red-500">
                   {carePlanError}
                 </div>
               ) : (
-                <CarePlan plan={carePlan} />
+                <CarePlan plan={carePlan} nickname={plant.nickname} />
               )}
+            </div>
+            <div className="mt-8">
+              <AnalyticsPanel plant={plant} weather={weather} />
             </div>
             <div className="mt-8">
               <Timeline events={plant.events} />

--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -3,12 +3,20 @@ import CarePlan from '../plant-detail/CarePlan'
 
 describe('CarePlan', () => {
   it('shows placeholder when plan is empty', () => {
-    render(<CarePlan plan={''} />)
+    render(<CarePlan plan={''} nickname="Delilah" />)
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan text', () => {
-    render(<CarePlan plan={'Water daily'} />)
-    expect(screen.getByText(/Water daily/i)).toBeInTheDocument()
+  it('renders provided plan sections', () => {
+    render(
+      <CarePlan
+        plan={'Light: Bright, indirect light\nWater: Every 7–10 days'}
+        nickname="Delilah"
+      />
+    )
+    expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
+    expect(screen.getByText(/Bright, indirect light/i)).toBeInTheDocument()
+    expect(screen.getByText(/Every 7–10 days/i)).toBeInTheDocument()
   })
 })
+

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,15 +1,61 @@
 'use client'
 
+import { Sun, Droplet, Sprout, Wind, Scissors, Leaf } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
 interface CarePlanProps {
   plan?: string | null
+  nickname: string
 }
 
-export default function CarePlan({ plan }: CarePlanProps) {
-  const content = plan && plan.trim() ? plan : 'No care plan available'
+interface Section {
+  key: string
+  icon: LucideIcon
+  text: string
+}
+
+export default function CarePlan({ plan, nickname }: CarePlanProps) {
+  const sectionsConfig: { key: string; icon: Section['icon'] }[] = [
+    { key: 'Light', icon: Sun },
+    { key: 'Water', icon: Droplet },
+    { key: 'Feeding', icon: Sprout },
+    { key: 'Humidity', icon: Wind },
+    { key: 'Pruning', icon: Scissors },
+  ]
+
+  const sections: Section[] = sectionsConfig
+    .map(({ key, icon }) => {
+      const regex = new RegExp(`${key}:\s*(.*)`, 'i')
+      const match = plan ? regex.exec(plan) : null
+      return match ? { key, icon, text: match[1].trim() } : null
+    })
+    .filter((s): s is Section => s !== null)
+
+  const hasPlan = plan && plan.trim()
+
   return (
-    <section className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
-      <h2 className="text-lg font-semibold mb-4">Care Plan</h2>
-      <pre className="whitespace-pre-line text-sm">{content}</pre>
+    <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
+      <h2 className="text-xl font-semibold mb-4 flex items-center">
+        <Leaf className="w-6 h-6 mr-2" />
+        Care Plan for {nickname}
+      </h2>
+      {!hasPlan ? (
+        <p className="text-sm text-gray-600 dark:text-gray-400">No care plan available</p>
+      ) : sections.length > 0 ? (
+        <ul className="space-y-3 text-sm">
+          {sections.map(({ key, icon: Icon, text }) => (
+            <li key={key} className="flex items-start">
+              <Icon className="w-5 h-5 mr-2 flex-shrink-0" />
+              <div>
+                <span className="font-medium">{key}: </span>
+                {text}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <pre className="whitespace-pre-line text-sm">{plan}</pre>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- restyle care plan with icon sections and plant-specific title
- move care plan above analytics charts
- adjust tests for new care plan structure

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ccdfe73c8324a2be5ce6c05be218