### PR TITLE
feat: add collapsible sidebar

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,10 +1,27 @@
+"use client"
+
+import { useState, useEffect } from "react"
 import SidebarNav from "@/components/SidebarNav"
 import MobileNav from "@/components/MobileNav"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem("sidebar-collapsed")
+    if (stored) setCollapsed(stored === "true")
+  }, [])
+
+  const toggle = () =>
+    setCollapsed((prev) => {
+      const next = !prev
+      localStorage.setItem("sidebar-collapsed", String(next))
+      return next
+    })
+
   return (
     <div className="flex flex-col md:flex-row min-h-screen">
-      <SidebarNav />
+      <SidebarNav collapsed={collapsed} toggle={toggle} />
       <div className="flex-1 flex flex-col pb-16 md:pb-0">{children}</div>
       <MobileNav />
     </div>

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -2,16 +2,37 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { motion } from "framer-motion"
+import { ChevronLeft, ChevronRight } from "lucide-react"
 
 import { navItems } from "./navItems"
 
-export default function SidebarNav() {
+interface SidebarNavProps {
+  collapsed: boolean
+  toggle: () => void
+}
+
+export default function SidebarNav({ collapsed, toggle }: SidebarNavProps) {
   const pathname = usePathname()
 
   return (
-    <aside className="hidden md:block md:w-64 bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 p-6">
+    <motion.aside
+      initial={false}
+      animate={{ width: collapsed ? 64 : 256 }}
+      className={`hidden md:flex flex-col bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 ${collapsed ? "p-2 items-center" : "p-6"} overflow-hidden`}
+    >
+      <button
+        onClick={toggle}
+        aria-label="Toggle sidebar"
+        className="self-end mb-4 p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800"
+      >
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4" />
+        ) : (
+          <ChevronLeft className="h-4 w-4" />
+        )}
+      </button>
       <nav
-        className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200"
+        className={`flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 ${collapsed ? "items-center" : ""}`}
         role="navigation"
         aria-label="Sidebar navigation"
       >
@@ -26,17 +47,17 @@ export default function SidebarNav() {
             >
               <Link
                 href={href}
-                className={`flex items-center px-2 py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
+                className={`flex items-center ${collapsed ? "justify-center px-0" : "px-2"} py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
                 aria-current={active ? "page" : undefined}
                 aria-label={label}
               >
-                <Icon className="h-5 w-5 mr-2" aria-hidden="true" />
-                {label}
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                {!collapsed && <span className="ml-2">{label}</span>}
               </Link>
             </motion.div>
           )
         })}
       </nav>
-    </aside>
+    </motion.aside>
   )
 }


### PR DESCRIPTION
## Summary
- add client-side state to dashboard layout to toggle sidebar collapse and store preference
- support collapsed mode in `SidebarNav` with animated width and toggle button

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ccefaefc8324917cb45817c69a74