### PR TITLE
feat: add collapsible care plan sections

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import CarePlan from '../plant-detail/CarePlan'
 
 describe('CarePlan', () => {
@@ -7,16 +8,21 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections', () => {
+  it('renders provided plan sections with collapsible details', async () => {
     render(
       <CarePlan
         plan={'Light: Bright, indirect light\nWater: Every 7–10 days'}
         nickname="Delilah"
       />
     )
+    const user = userEvent.setup()
+
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
-    expect(screen.getByText(/Bright, indirect light/i)).toBeInTheDocument()
-    expect(screen.getByText(/Every 7–10 days/i)).toBeInTheDocument()
+    // Summary is shown
+    expect(screen.getAllByText(/Bright, indirect light/i)).toHaveLength(1)
+    // Expand details
+    await user.click(screen.getByRole('button', { name: /Light/i }))
+    expect(screen.getAllByText(/Bright, indirect light/i)).toHaveLength(2)
   })
 })
 

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { Sun, Droplet, Sprout, Wind, Scissors, Leaf } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
@@ -32,6 +33,17 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
     .filter((s): s is Section => s !== null)
 
   const hasPlan = plan && plan.trim()
+  const [openSections, setOpenSections] = useState<string[]>([])
+
+  const toggleSection = (key: string) => {
+    setOpenSections((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
+    )
+  }
+
+  const allOpen = openSections.length === sections.length
+  const toggleAll = () =>
+    setOpenSections(allOpen ? [] : sections.map((s) => s.key))
 
   return (
     <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
@@ -42,17 +54,50 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
       {!hasPlan ? (
         <p className="text-sm text-gray-600 dark:text-gray-400">No care plan available</p>
       ) : sections.length > 0 ? (
-        <ul className="space-y-3 text-sm">
-          {sections.map(({ key, icon: Icon, text }) => (
-            <li key={key} className="flex items-start">
-              <Icon className="w-5 h-5 mr-2 flex-shrink-0" />
-              <div>
-                <span className="font-medium">{key}: </span>
-                {text}
-              </div>
-            </li>
-          ))}
-        </ul>
+        <>
+          <div className="mb-4">
+            <h3 className="text-lg font-medium mb-2">Overview</h3>
+            <ul className="list-disc list-inside text-sm">
+              {sections.map(({ key, text }) => {
+                const summary = text.split('. ')[0]
+                return (
+                  <li key={key}>
+                    <span className="font-medium">{key}:</span> {summary}
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+          <div className="flex justify-end mb-2">
+            <button
+              type="button"
+              className="text-xs text-blue-600 dark:text-blue-400"
+              onClick={toggleAll}
+            >
+              {allOpen ? 'Collapse all' : 'Show all'}
+            </button>
+          </div>
+          <div className="space-y-2">
+            {sections.map(({ key, icon: Icon, text }) => {
+              const isOpen = openSections.includes(key)
+              return (
+                <div key={key} className="border rounded-md">
+                  <button
+                    type="button"
+                    className="w-full flex items-center p-2 text-left"
+                    onClick={() => toggleSection(key)}
+                  >
+                    <Icon className="w-5 h-5 mr-2 flex-shrink-0" />
+                    <span className="font-medium">{key}</span>
+                  </button>
+                  {isOpen && (
+                    <div className="p-2 pt-0 text-sm">{text}</div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </>
       ) : (
         <pre className="whitespace-pre-line text-sm">{plan}</pre>
       )}


### PR DESCRIPTION
## Summary
- add overview and accordion behavior to plant care plan
- include toggle to show or collapse all sections
- test coverage for collapsible care plan details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5cf904c6c832481b4a2e3504a5f17