### PR TITLE
Parse structured care plans

### DIFF
--- a/app/api/plants/[id]/care-plan/route.ts
+++ b/app/api/plants/[id]/care-plan/route.ts
@@ -12,7 +12,7 @@ export async function GET(
 
   if (!plant.carePlan) {
     const apiKey = process.env.OPENAI_API_KEY
-    const prompt = `Provide a detailed weekly care plan for a ${plant.species} named ${plant.nickname}.`
+    const prompt = `Generate a care plan for a ${plant.species} named ${plant.nickname} as a JSON object with the keys light, water, humidity, temperature, soil, fertilization, pruning, pests, and overview. Each value should be a concise sentence. Return only JSON.`
 
     if (!apiKey) {
       plant.carePlan =
@@ -43,7 +43,8 @@ export async function GET(
       }
 
       const data = await res.json()
-      plant.carePlan = data.choices?.[0]?.message?.content?.trim() || ''
+      const content = data.choices?.[0]?.message?.content?.trim() || '{}'
+      plant.carePlan = JSON.parse(content)
     } catch (err) {
       return NextResponse.json(
         { error: err instanceof Error ? err.message : 'Unknown error' },

--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import CarePlan from '../plant-detail/CarePlan'
 
 describe('CarePlan', () => {
@@ -8,15 +8,38 @@ describe('CarePlan', () => {
   })
 
   it('renders provided plan sections', () => {
-    render(
-      <CarePlan
-        plan={'Light: Bright, indirect light\nWater: Every 7–10 days'}
-        nickname="Delilah"
-      />
-    )
-    expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
-    expect(screen.getByText(/Bright, indirect light/i)).toBeInTheDocument()
-    expect(screen.getByText(/Every 7–10 days/i)).toBeInTheDocument()
+    const plan = {
+      light: 'Bright, indirect light',
+      water: 'Every 7–10 days',
+      humidity: 'Moderate humidity',
+      temperature: '65-75°F',
+      soil: 'Well-draining soil',
+      fertilization: 'Monthly fertilizer',
+      pruning: 'Trim yellow leaves',
+      pests: 'Check for spider mites',
+      overview: 'Keep soil moist but not soggy.',
+    }
+
+    render(<CarePlan plan={JSON.stringify(plan)} nickname="Delilah" />)
+
+    const expected = {
+      Light: plan.light,
+      Water: plan.water,
+      Humidity: plan.humidity,
+      Temperature: plan.temperature,
+      Soil: plan.soil,
+      Fertilization: plan.fertilization,
+      Pruning: plan.pruning,
+      Pests: plan.pests,
+      Overview: plan.overview,
+    }
+
+    Object.entries(expected).forEach(([label, text]) => {
+      const item = screen.getByText(new RegExp(`${label}:`, 'i')).closest('li')
+      expect(item).toBeInTheDocument()
+      expect(within(item as HTMLElement).getByText(text)).toBeInTheDocument()
+      expect(item?.querySelector('svg')).toBeInTheDocument()
+    })
   })
 })
 

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,37 +1,75 @@
 'use client'
 
-import { Sun, Droplet, Sprout, Wind, Scissors, Leaf } from 'lucide-react'
+import {
+  Sun,
+  Droplet,
+  Droplets,
+  Thermometer,
+  Sprout,
+  FlaskConical,
+  Scissors,
+  Bug,
+  BookOpen,
+  Leaf,
+} from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
+interface CarePlanData {
+  light?: string
+  water?: string
+  humidity?: string
+  temperature?: string
+  soil?: string
+  fertilization?: string
+  pruning?: string
+  pests?: string
+  overview?: string
+}
+
 interface CarePlanProps {
-  plan?: string | null
+  plan?: string | CarePlanData | null
   nickname: string
 }
 
 interface Section {
-  key: string
+  label: string
   icon: LucideIcon
   text: string
 }
 
 export default function CarePlan({ plan, nickname }: CarePlanProps) {
-  const sectionsConfig: { key: string; icon: Section['icon'] }[] = [
-    { key: 'Light', icon: Sun },
-    { key: 'Water', icon: Droplet },
-    { key: 'Feeding', icon: Sprout },
-    { key: 'Humidity', icon: Wind },
-    { key: 'Pruning', icon: Scissors },
+  let planObj: CarePlanData | null = null
+  if (plan) {
+    try {
+      planObj = typeof plan === 'string' ? JSON.parse(plan) : plan
+    } catch {
+      planObj = null
+    }
+  }
+
+  const sectionsConfig: { key: keyof CarePlanData; label: string; icon: Section['icon'] }[] = [
+    { key: 'light', label: 'Light', icon: Sun },
+    { key: 'water', label: 'Water', icon: Droplet },
+    { key: 'humidity', label: 'Humidity', icon: Droplets },
+    { key: 'temperature', label: 'Temperature', icon: Thermometer },
+    { key: 'soil', label: 'Soil', icon: Sprout },
+    { key: 'fertilization', label: 'Fertilization', icon: FlaskConical },
+    { key: 'pruning', label: 'Pruning', icon: Scissors },
+    { key: 'pests', label: 'Pests', icon: Bug },
+    { key: 'overview', label: 'Overview', icon: BookOpen },
   ]
 
-  const sections: Section[] = sectionsConfig
-    .map(({ key, icon }) => {
-      const regex = new RegExp(`${key}:\s*(.*)`, 'i')
-      const match = plan ? regex.exec(plan) : null
-      return match ? { key, icon, text: match[1].trim() } : null
-    })
-    .filter((s): s is Section => s !== null)
+  const sections: Section[] = planObj
+    ? sectionsConfig
+        .filter(({ key }) => planObj && planObj[key])
+        .map(({ key, label, icon }) => ({
+          label,
+          icon,
+          text: planObj![key] as string,
+        }))
+    : []
 
-  const hasPlan = plan && plan.trim()
+  const hasPlan = !!plan
 
   return (
     <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
@@ -43,18 +81,20 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
         <p className="text-sm text-gray-600 dark:text-gray-400">No care plan available</p>
       ) : sections.length > 0 ? (
         <ul className="space-y-3 text-sm">
-          {sections.map(({ key, icon: Icon, text }) => (
-            <li key={key} className="flex items-start">
+          {sections.map(({ label, icon: Icon, text }) => (
+            <li key={label} className="flex items-start">
               <Icon className="w-5 h-5 mr-2 flex-shrink-0" />
               <div>
-                <span className="font-medium">{key}: </span>
+                <span className="font-medium">{label}: </span>
                 {text}
               </div>
             </li>
           ))}
         </ul>
       ) : (
-        <pre className="whitespace-pre-line text-sm">{plan}</pre>
+        <pre className="whitespace-pre-line text-sm">
+          {typeof plan === 'string' ? plan : JSON.stringify(plan, null, 2)}
+        </pre>
       )}
     </section>
   )

--- a/lib/plants.ts
+++ b/lib/plants.ts
@@ -5,6 +5,18 @@ export interface PlantEvent {
   note?: string
 }
 
+export interface CarePlan {
+  light?: string
+  water?: string
+  humidity?: string
+  temperature?: string
+  soil?: string
+  fertilization?: string
+  pruning?: string
+  pests?: string
+  overview?: string
+}
+
 export interface Plant {
   nickname: string
   species: string
@@ -19,7 +31,7 @@ export interface Plant {
   nutrientLevel?: number
   events: PlantEvent[]
   photos: string[]
-  carePlan?: string
+  carePlan?: CarePlan | string
 }
 
 export const samplePlants: Record<string, Plant> = {


### PR DESCRIPTION
## Summary
- Request structured JSON care plans from OpenAI and parse the response before returning
- Display care plans by parsing JSON and mapping each section to icons
- Define a CarePlan model and update tests for JSON-based plans

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cf8a01cc8324b79e3882a0324388