### PR TITLE
feat: parse structured care plans

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -38,7 +38,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
   const toast = useToast()
   const [weather, setWeather] = useState<Weather | null>(null)
   const [offline, setOffline] = useState(false)
-  const [carePlan, setCarePlan] = useState<string | null>(null)
+  const [carePlan, setCarePlan] = useState<Record<string, string> | null>(null)
   const [carePlanError, setCarePlanError] = useState<string | null>(null)
   const [carePlanLoading, setCarePlanLoading] = useState(false)
 
@@ -217,10 +217,10 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
     fetch(`/api/plants/${params.id}/care-plan`)
       .then((res) => {
         if (!res.ok) throw new Error(`Error ${res.status}`)
-        return res.text()
+        return res.json()
       })
-      .then((text) => {
-        if (active) setCarePlan(text)
+      .then((data) => {
+        if (active) setCarePlan(data.carePlan)
       })
       .catch((err) => {
         if (active)

--- a/app/api/plants/[id]/care-plan/route.ts
+++ b/app/api/plants/[id]/care-plan/route.ts
@@ -12,12 +12,12 @@ export async function GET(
 
   if (!plant.carePlan) {
     const apiKey = process.env.OPENAI_API_KEY
-    const prompt = `Provide a detailed weekly care plan for a ${plant.species} named ${plant.nickname}.`
+    const prompt = `Provide a weekly care plan for a ${plant.species} named ${plant.nickname} as a JSON object with the keys: light, water, humidity, temperature, soil, fertilization, pruning, pests, overview. Respond only with valid JSON.`
 
     if (!apiKey) {
-      plant.carePlan =
-        plant.carePlan ||
-        'Set OPENAI_API_KEY to enable AI-generated care plans.'
+      plant.carePlan = {
+        overview: 'Set OPENAI_API_KEY to enable AI-generated care plans.',
+      }
       return NextResponse.json({ carePlan: plant.carePlan })
     }
 
@@ -43,7 +43,8 @@ export async function GET(
       }
 
       const data = await res.json()
-      plant.carePlan = data.choices?.[0]?.message?.content?.trim() || ''
+      const content = data.choices?.[0]?.message?.content?.trim() || '{}'
+      plant.carePlan = JSON.parse(content)
     } catch (err) {
       return NextResponse.json(
         { error: err instanceof Error ? err.message : 'Unknown error' },

--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -8,21 +8,31 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections with collapsible details', async () => {
-    render(
-      <CarePlan
-        plan={'Light: Bright, indirect light\nWater: Every 7–10 days'}
-        nickname="Delilah"
-      />
-    )
+  it('renders provided plan sections with icons and collapsible details', async () => {
+    const plan = {
+      overview: 'General care overview',
+      light: 'Bright, indirect light',
+      water: 'Every 7–10 days',
+      humidity: 'Moderate humidity',
+      temperature: '65-75°F',
+      soil: 'Well-draining potting mix',
+      fertilization: 'Feed monthly',
+      pruning: 'Trim as needed',
+      pests: 'Watch for aphids',
+    }
+
+    render(<CarePlan plan={plan} nickname="Delilah" />)
     const user = userEvent.setup()
 
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
-    // Summary is shown
-    expect(screen.getAllByText(/Bright, indirect light/i)).toHaveLength(1)
-    // Expand details
-    await user.click(screen.getByRole('button', { name: /Light/i }))
-    expect(screen.getAllByText(/Bright, indirect light/i)).toHaveLength(2)
+
+    for (const [key, text] of Object.entries(plan)) {
+      const label = key.charAt(0).toUpperCase() + key.slice(1)
+      const button = screen.getByRole('button', { name: new RegExp(label, 'i') })
+      expect(button.querySelector('svg')).toBeInTheDocument()
+      await user.click(button)
+      expect(screen.getByText(text)).toBeInTheDocument()
+    }
   })
 })
 

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,11 +1,22 @@
 'use client'
 
 import { useState } from 'react'
-import { Sun, Droplet, Sprout, Wind, Scissors, Leaf } from 'lucide-react'
+import {
+  Sun,
+  Droplet,
+  Wind,
+  Thermometer,
+  Flower2,
+  Sprout,
+  Scissors,
+  Bug,
+  BookOpen,
+  Leaf,
+} from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 interface CarePlanProps {
-  plan?: string | null
+  plan?: string | Record<string, string> | null
   nickname: string
 }
 
@@ -16,23 +27,32 @@ interface Section {
 }
 
 export default function CarePlan({ plan, nickname }: CarePlanProps) {
-  const sectionsConfig: { key: string; icon: Section['icon'] }[] = [
-    { key: 'Light', icon: Sun },
-    { key: 'Water', icon: Droplet },
-    { key: 'Feeding', icon: Sprout },
-    { key: 'Humidity', icon: Wind },
-    { key: 'Pruning', icon: Scissors },
+  const planObj: Record<string, string> | null = plan
+    ? typeof plan === 'string'
+      ? JSON.parse(plan)
+      : plan
+    : null
+
+  const sectionsConfig: { key: string; label: string; icon: LucideIcon }[] = [
+    { key: 'overview', label: 'Overview', icon: BookOpen },
+    { key: 'light', label: 'Light', icon: Sun },
+    { key: 'water', label: 'Water', icon: Droplet },
+    { key: 'humidity', label: 'Humidity', icon: Wind },
+    { key: 'temperature', label: 'Temperature', icon: Thermometer },
+    { key: 'soil', label: 'Soil', icon: Flower2 },
+    { key: 'fertilization', label: 'Fertilization', icon: Sprout },
+    { key: 'pruning', label: 'Pruning', icon: Scissors },
+    { key: 'pests', label: 'Pests', icon: Bug },
   ]
 
   const sections: Section[] = sectionsConfig
-    .map(({ key, icon }) => {
-      const regex = new RegExp(`${key}:\s*(.*)`, 'i')
-      const match = plan ? regex.exec(plan) : null
-      return match ? { key, icon, text: match[1].trim() } : null
+    .map(({ key, label, icon }) => {
+      const text = planObj?.[key]
+      return text ? { key: label, icon, text } : null
     })
     .filter((s): s is Section => s !== null)
 
-  const hasPlan = plan && plan.trim()
+  const hasPlan = !!planObj
   const [openSections, setOpenSections] = useState<string[]>([])
 
   const toggleSection = (key: string) => {
@@ -52,22 +72,11 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
         Care Plan for {nickname}
       </h2>
       {!hasPlan ? (
-        <p className="text-sm text-gray-600 dark:text-gray-400">No care plan available</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          No care plan available
+        </p>
       ) : sections.length > 0 ? (
         <>
-          <div className="mb-4">
-            <h3 className="text-lg font-medium mb-2">Overview</h3>
-            <ul className="list-disc list-inside text-sm">
-              {sections.map(({ key, text }) => {
-                const summary = text.split('. ')[0]
-                return (
-                  <li key={key}>
-                    <span className="font-medium">{key}:</span> {summary}
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
           <div className="flex justify-end mb-2">
             <button
               type="button"
@@ -90,16 +99,16 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
                     <Icon className="w-5 h-5 mr-2 flex-shrink-0" />
                     <span className="font-medium">{key}</span>
                   </button>
-                  {isOpen && (
-                    <div className="p-2 pt-0 text-sm">{text}</div>
-                  )}
+                  {isOpen && <div className="p-2 pt-0 text-sm">{text}</div>}
                 </div>
               )
             })}
           </div>
         </>
       ) : (
-        <pre className="whitespace-pre-line text-sm">{plan}</pre>
+        <pre className="whitespace-pre-line text-sm">
+          {typeof plan === 'string' ? plan : JSON.stringify(plan, null, 2)}
+        </pre>
       )}
     </section>
   )

--- a/lib/plants.ts
+++ b/lib/plants.ts
@@ -19,7 +19,7 @@ export interface Plant {
   nutrientLevel?: number
   events: PlantEvent[]
   photos: string[]
-  carePlan?: string
+  carePlan?: Record<string, string>
 }
 
 export const samplePlants: Record<string, Plant> = {


### PR DESCRIPTION
## Summary
- request structured care plans as JSON from the API and parse the response
- render care plan sections from parsed objects with appropriate icons
- test care plan rendering with JSON data

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5d0eab9448324b6c7efa1d4514ca1