### PR TITLE
Refine plant analytics charts

### DIFF
--- a/components/ChartCard.tsx
+++ b/components/ChartCard.tsx
@@ -6,11 +6,24 @@ interface ChartCardProps {
   title: string
   insight: string
   children: ReactNode
+  variant?: 'primary' | 'secondary'
 }
 
-export default function ChartCard({ title, insight, children }: ChartCardProps) {
+export default function ChartCard({
+  title,
+  insight,
+  children,
+  variant = 'secondary',
+}: ChartCardProps) {
+  const base =
+    'snap-start rounded-lg p-4 border border-transparent dark:border-transparent'
+  const variantClasses =
+    variant === 'primary'
+      ? 'min-w-full md:min-w-0 bg-white dark:bg-gray-900'
+      : 'flex-shrink-0 min-w-[260px] md:min-w-0 bg-gray-50 dark:bg-gray-800'
+
   return (
-    <div className="flex-shrink-0 min-w-full md:min-w-0 snap-start rounded-lg bg-white dark:bg-gray-900 p-4 shadow-sm">
+    <div className={`${base} ${variantClasses}`}>
       <h4 className="font-semibold mb-2 text-gray-900 dark:text-gray-100">{title}</h4>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{insight}</p>
       {children}

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -93,24 +93,23 @@ export function TempHumidityChart({
   return (
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={chartData}>
-        <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
-        <XAxis dataKey="day" />
-        <YAxis />
+        <XAxis dataKey="day" tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
+        <YAxis tickLine={false} axisLine={false} />
         <Tooltip content={<CustomTooltip />} />
-        <Legend />
-        <ReferenceArea y1={40} y2={60} fill="#dcfce7" fillOpacity={0.1} />
+        <ReferenceArea y1={20} y2={27} fill="#ecfdf5" fillOpacity={0.3} />
+        <ReferenceArea y1={40} y2={60} fill="#dbeafe" fillOpacity={0.3} />
         <Line
           type="monotone"
           dataKey="temp"
           stroke="#f87171"
-          strokeWidth={2}
-          name={tempUnit === "F" ? "Temp (°F)" : "Temp (°C)"}
+          strokeWidth={3}
+          name={tempUnit === 'F' ? 'Temp (°F)' : 'Temp (°C)'}
         />
         <Line
           type="monotone"
           dataKey="rh"
           stroke="#60a5fa"
-          strokeWidth={2}
+          strokeWidth={3}
           name="RH (%)"
         />
       </LineChart>
@@ -194,18 +193,17 @@ export function HydrationTrendChart({
   return (
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
-        <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
+        <YAxis domain={[0, 100]} tickLine={false} axisLine={false} />
         <Tooltip content={<CustomTooltip />} />
-        <Legend />
-        <ReferenceArea y1={0} y2={40} fill="#fecaca" fillOpacity={0.1} />
-        <ReferenceArea y1={40} y2={100} fill="#dcfce7" fillOpacity={0.1} />
+        <ReferenceArea y1={0} y2={40} fill="#fee2e2" fillOpacity={0.5} />
+        <ReferenceArea y1={40} y2={80} fill="#dcfce7" fillOpacity={0.5} />
+        <ReferenceArea y1={80} y2={100} fill="#dbeafe" fillOpacity={0.5} />
         <Line
           type="monotone"
           dataKey="actual"
           stroke="#3b82f6"
-          strokeWidth={2}
+          strokeWidth={3}
           name="Hydration (%)"
         />
         <Line
@@ -213,7 +211,7 @@ export function HydrationTrendChart({
           dataKey="forecast"
           stroke="#93c5fd"
           strokeDasharray="4 4"
-          strokeWidth={2}
+          strokeWidth={3}
           name="Forecast"
         />
       </LineChart>
@@ -386,19 +384,17 @@ export function WaterBalanceChart({
   return (
     <ResponsiveContainer width="100%" height={250}>
       <ComposedChart data={data}>
-        <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
-        <XAxis dataKey="date" />
-        <YAxis />
+        <XAxis dataKey="date" tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
+        <YAxis tickLine={false} axisLine={false} />
         <Tooltip content={<CustomTooltip />} />
-        <Legend />
-        <ReferenceArea y1={0} y2={5} fill="#e0f2fe" fillOpacity={0.1} />
+        <ReferenceArea y1={0} y2={5} fill="#e0f2fe" fillOpacity={0.3} />
         {showWater && <Bar dataKey="water" fill="#3b82f6" name="Water (mm)" />}
         {showEt && (
           <Line
             type="monotone"
             dataKey="et0"
             stroke="#f59e0b"
-            strokeWidth={2}
+            strokeWidth={3}
             name="ET₀ (mm)"
           />
         )}
@@ -471,16 +467,15 @@ export function StressIndexChart({ data }: { data: StressDatum[] }) {
   return (
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
-        <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
-        <XAxis dataKey="date" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="date" tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
+        <YAxis domain={[0, 100]} tickLine={false} axisLine={false} />
         <Tooltip content={<CustomTooltip />} />
-        <ReferenceArea y1={0} y2={30} fill="#dcfce7" fillOpacity={0.1} />
+        <ReferenceArea y1={0} y2={30} fill="#dcfce7" fillOpacity={0.5} />
         <Line
           type="monotone"
           dataKey="stress"
           stroke="#ef4444"
-          strokeWidth={2}
+          strokeWidth={3}
           name="Stress"
         />
       </LineChart>
@@ -524,17 +519,15 @@ export function NutrientLevelChart({
   return (
     <ResponsiveContainer width="100%" height={250}>
       <LineChart data={data}>
-        <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
-        <XAxis dataKey="day" />
-        <YAxis domain={[0, 100]} />
+        <XAxis dataKey="day" tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
+        <YAxis domain={[0, 100]} tickLine={false} axisLine={false} />
         <Tooltip content={<CustomTooltip />} />
-        <Legend />
-        <ReferenceArea y1={60} y2={100} fill="#dcfce7" fillOpacity={0.1} />
+        <ReferenceArea y1={60} y2={100} fill="#dcfce7" fillOpacity={0.5} />
         <Line
           type="monotone"
           dataKey="level"
           stroke="#16a34a"
-          strokeWidth={2}
+          strokeWidth={3}
           name="Nutrients (%)"
         />
         <Line
@@ -542,7 +535,7 @@ export function NutrientLevelChart({
           dataKey="forecast"
           stroke="#86efac"
           strokeDasharray="4 4"
-          strokeWidth={2}
+          strokeWidth={3}
           name="Forecast"
         />
       </LineChart>

--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -26,6 +26,7 @@ export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) 
   const [timeframe, setTimeframe] = useState<keyof typeof ranges>('week')
   const [showEt, setShowEt] = useState(true)
   const [showWater, setShowWater] = useState(true)
+  const [tab, setTab] = useState<'plant' | 'environment' | 'hydration'>('plant')
 
   const weatherHistory = useMemo<WeatherDay[]>(() => {
     const base = {
@@ -108,12 +109,23 @@ export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) 
     return stressTrend(readings)
   }, [waterData, weatherHistory, filteredWaterEvents])
 
-  return (
-    <>
-      <VitalsSummary plant={plant} weather={weather} />
-      <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800 space-y-6">
-        <EnvironmentBlock env={env} envChartData={envChartData} />
+  const sections = [
+    {
+      key: 'plant' as const,
+      label: 'Plant Health',
+      content: (
         <StressBlock plant={plant} weather={weather} stressData={stressData} />
+      ),
+    },
+    {
+      key: 'environment' as const,
+      label: 'Environment',
+      content: <EnvironmentBlock env={env} envChartData={envChartData} />,
+    },
+    {
+      key: 'hydration' as const,
+      label: 'Hydration & Nutrients',
+      content: (
         <HydrationBlock
           plant={plant}
           waterData={waterData}
@@ -124,6 +136,37 @@ export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) 
           showWater={showWater}
           setShowWater={setShowWater}
         />
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <VitalsSummary plant={plant} weather={weather} />
+      <div className="mb-4 flex gap-2 md:hidden">
+        {sections.map((s) => (
+          <button
+            key={s.key}
+            onClick={() => setTab(s.key)}
+            className={`px-3 py-1 text-sm rounded ${
+              tab === s.key
+                ? 'bg-gray-200 dark:bg-gray-700'
+                : 'bg-transparent'
+            }`}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+      <section className="rounded-xl p-6 shadow-sm bg-gray-50 dark:bg-gray-800 space-y-6">
+        {sections.map((s) => (
+          <div
+            key={s.key}
+            className={`${tab === s.key ? 'block' : 'hidden'} md:block`}
+          >
+            {s.content}
+          </div>
+        ))}
       </section>
     </>
   )

--- a/components/plant-detail/EnvironmentBlock.tsx
+++ b/components/plant-detail/EnvironmentBlock.tsx
@@ -37,10 +37,14 @@ export default function EnvironmentBlock({ env, envChartData }: EnvironmentBlock
       </p>
       <EnvRow temperature={env.temperature} humidity={env.humidity} vpd={env.vpd} tempUnit="C" />
       <div className="mt-4 flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
-        <ChartCard title="Temperature & Humidity" insight="Daily temperature and humidity readings.">
+        <ChartCard
+          title="Temperature & Humidity"
+          insight="Comfort zone"
+          variant="secondary"
+        >
           <TempHumidityChart tempUnit="C" data={envChartData} />
         </ChartCard>
-        <ChartCard title="VPD" insight="Vapor pressure deficit">
+        <ChartCard title="VPD" insight="VPD gauge" variant="secondary">
           <VPDGauge value={env.vpd} />
         </ChartCard>
       </div>

--- a/components/plant-detail/HydrationBlock.tsx
+++ b/components/plant-detail/HydrationBlock.tsx
@@ -9,10 +9,6 @@ const NutrientLevelChart = dynamic(
   () => import('@/components/Charts').then((m) => m.NutrientLevelChart),
   { ssr: false, loading: () => <p>Loading chart...</p> }
 )
-const HydrationTrendChart = dynamic(
-  () => import('@/components/Charts').then((m) => m.HydrationTrendChart),
-  { ssr: false, loading: () => <p>Loading chart...</p> }
-)
 const WaterBalanceChart = dynamic(
   () => import('@/components/Charts').then((m) => m.WaterBalanceChart),
   { ssr: false, loading: () => <p>Loading chart...</p> }
@@ -45,21 +41,26 @@ export default function HydrationBlock({
     <details id="hydration" open>
       <summary className="text-lg font-semibold cursor-pointer">Hydration & Nutrients</summary>
       <p className="text-sm text-gray-500 mb-4">
-        Hydration history and nutrient levels.
+        Nutrient levels and water balance.
       </p>
       <div className="flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
-        <ChartCard title="Nutrient Levels" insight="Nutrient availability over time">
+        <ChartCard
+          title="Nutrient Levels"
+          insight={`Next feed due ${(() => {
+            const d = new Date(plant.lastFertilized)
+            d.setMonth(d.getMonth() + 1)
+            return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+          })()}`}
+          variant="secondary"
+        >
           <NutrientLevelChart
             lastFertilized={plant.lastFertilized}
             nutrientLevel={plant.nutrientLevel ?? 100}
           />
         </ChartCard>
-        <ChartCard title="Hydration Trend" insight="Hydration history">
-          <HydrationTrendChart log={plant.hydrationLog ?? []} />
-        </ChartCard>
       </div>
       <div className="mt-4 flex overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
-        <ChartCard title="Water Balance" insight="Water balance with ET0">
+        <ChartCard title="Water Balance" insight="ET₀ vs water" variant="secondary">
           <div className="mb-2 flex items-center gap-2">
             <div className="flex gap-1">
               {(['day', 'week', 'month'] as (keyof typeof ranges)[]).map((tf) => (

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -2,14 +2,10 @@
 
 import dynamic from 'next/dynamic'
 import ChartCard from '@/components/ChartCard'
-import { calculateStressIndex, type StressDatum } from '@/lib/plant-metrics'
+import { type StressDatum } from '@/lib/plant-metrics'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 
-const StressIndexGauge = dynamic(
-  () => import('@/components/Charts').then((m) => m.StressIndexGauge),
-  { ssr: false, loading: () => <p>Loading chart...</p> }
-)
 const PlantHealthRadar = dynamic(
   () => import('@/components/Charts').then((m) => m.PlantHealthRadar),
   { ssr: false, loading: () => <p>Loading chart...</p> }
@@ -33,17 +29,7 @@ export default function StressBlock({ plant, weather, stressData }: StressBlockP
         Stress index overview and overall health radar.
       </p>
       <div className="flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
-        <ChartCard title="Stress Index" insight="Current plant stress level">
-          <StressIndexGauge
-            value={calculateStressIndex({
-              overdueDays: plant.status === 'Water overdue' ? 1 : 0,
-              hydration: plant.hydration,
-              temperature: weather?.temperature ?? 25,
-              light: 50,
-            })}
-          />
-        </ChartCard>
-        <ChartCard title="Plant Health" insight="Overall health radar">
+        <ChartCard title="Plant Health" insight="Overall health radar" variant="secondary">
           <PlantHealthRadar
             hydration={plant.hydration}
             lastFertilized={plant.lastFertilized}
@@ -53,9 +39,7 @@ export default function StressBlock({ plant, weather, stressData }: StressBlockP
             weather={weather}
           />
         </ChartCard>
-      </div>
-      <div className="mt-4 flex overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
-        <ChartCard title="Stress Trend" insight="Stress index over time">
+        <ChartCard title="Stress Trend" insight="Stress trending down" variant="secondary">
           <StressIndexChart data={stressData} />
         </ChartCard>
       </div>

--- a/components/plant-detail/VitalsSummary.tsx
+++ b/components/plant-detail/VitalsSummary.tsx
@@ -1,10 +1,19 @@
 'use client'
 
-import Link from 'next/link'
-import { Activity, Droplet, Calendar } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { calculateStressIndex } from '@/lib/plant-metrics'
+import ChartCard from '@/components/ChartCard'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
+
+const StressIndexGauge = dynamic(
+  () => import('@/components/Charts').then((m) => m.StressIndexGauge),
+  { ssr: false, loading: () => <p>Loading chart...</p> },
+)
+const HydrationTrendChart = dynamic(
+  () => import('@/components/Charts').then((m) => m.HydrationTrendChart),
+  { ssr: false, loading: () => <p>Loading chart...</p> },
+)
 
 interface VitalsSummaryProps {
   plant: Plant
@@ -20,25 +29,17 @@ export default function VitalsSummary({ plant, weather }: VitalsSummaryProps) {
       light: 50,
     }),
   )
-
   const stressLabel =
     stressValue < 30 ? 'Low' : stressValue <= 70 ? 'Moderate' : 'High'
 
   return (
-    <div className="flex justify-around mb-6">
-      <Link href="#plant-health" className="flex flex-col items-center gap-2">
-        <Activity className="h-8 w-8" strokeWidth={3} />
-        <span className="text-2xl font-bold">{stressLabel} Stress</span>
-      </Link>
-      <Link href="#hydration" className="flex flex-col items-center gap-2">
-        <Droplet className="h-8 w-8" strokeWidth={3} />
-        <span className="text-2xl font-bold">{plant.hydration}% Hydration</span>
-      </Link>
-      <Link href="#hydration" className="flex flex-col items-center gap-2">
-        <Calendar className="h-8 w-8" strokeWidth={3} />
-        <span className="text-2xl font-bold">Next water {plant.nextDue}</span>
-      </Link>
+    <div className="grid gap-6 mb-6 md:grid-cols-2">
+      <ChartCard title="Stress" insight={stressLabel} variant="primary">
+        <StressIndexGauge value={stressValue} />
+      </ChartCard>
+      <ChartCard title="Hydration" insight="Hydration stable this week" variant="primary">
+        <HydrationTrendChart log={plant.hydrationLog ?? []} />
+      </ChartCard>
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- split analytics into mobile tabs
- redesign vitals with stress and hydration focus
- simplify secondary environment and nutrient cards

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d017d5708324825f353825022518