### PR TITLE
Refactor sidebar nav to semantic list

### DIFF
--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -36,31 +36,34 @@ export default function SidebarNav({ collapsed, toggle }: SidebarNavProps) {
       </button>
       <nav
         id="sidebar-nav"
-        className={`flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 ${collapsed ? "items-center" : ""}`}
         role="navigation"
         aria-label="Sidebar navigation"
       >
-        {navItems.map(({ href, label, icon: Icon }) => {
-          const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
-          return (
-            <motion.div
-              key={href}
-              whileHover={{ scale: 1.03 }}
-              whileFocus={{ scale: 1.03 }}
-              whileTap={{ scale: 0.97 }}
-            >
-              <Link
-                href={href}
-                className={`flex items-center ${collapsed ? "justify-center px-0" : "px-2"} py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
-                aria-current={active ? "page" : undefined}
-                aria-label={label}
+        <ul
+          className={`flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 ${collapsed ? "items-center" : ""}`}
+        >
+          {navItems.map(({ href, label, icon: Icon }) => {
+            const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
+            return (
+              <motion.li
+                key={href}
+                whileHover={{ scale: 1.03 }}
+                whileFocus={{ scale: 1.03 }}
+                whileTap={{ scale: 0.97 }}
               >
-                <Icon className="h-5 w-5" aria-hidden="true" />
-                {!collapsed && <span className="ml-2">{label}</span>}
-              </Link>
-            </motion.div>
-          )
-        })}
+                <Link
+                  href={href}
+                  className={`flex items-center ${collapsed ? "justify-center px-0" : "px-2"} py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
+                  aria-current={active ? "page" : undefined}
+                  aria-label={label}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                  {!collapsed && <span className="ml-2">{label}</span>}
+                </Link>
+              </motion.li>
+            )
+          })}
+        </ul>
       </nav>
     </motion.aside>
   )


### PR DESCRIPTION
## Summary
- use `<ul>` and `<li>` for sidebar nav items
- preserve motion animations on list items

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d39147c88324bfec2ee0ab4644ba