### PR TITLE
feat: add desktop top navigation

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,27 +1,12 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import SidebarNav from "@/components/SidebarNav"
+import DesktopTopNav from "@/components/DesktopTopNav"
 import MobileNav from "@/components/MobileNav"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const [collapsed, setCollapsed] = useState(false)
-
-  useEffect(() => {
-    const stored = localStorage.getItem("sidebar-collapsed")
-    if (stored) setCollapsed(stored === "true")
-  }, [])
-
-  const toggle = () =>
-    setCollapsed((prev) => {
-      const next = !prev
-      localStorage.setItem("sidebar-collapsed", String(next))
-      return next
-    })
-
   return (
-    <div className="flex flex-col md:flex-row min-h-screen">
-      <SidebarNav collapsed={collapsed} toggle={toggle} />
+    <div className="flex flex-col min-h-screen">
+      <DesktopTopNav />
       <div className="flex-1 flex flex-col pb-16 md:pb-0">{children}</div>
       <MobileNav />
     </div>

--- a/components/DesktopTopNav.tsx
+++ b/components/DesktopTopNav.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { motion } from "framer-motion"
+
+import { navItems } from "./navItems"
+
+export default function DesktopTopNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav
+      className="hidden md:block sticky top-0 z-10 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+      role="navigation"
+      aria-label="Desktop navigation"
+    >
+      <ul className="flex justify-center gap-4 p-2 text-sm">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
+          return (
+            <motion.li
+              key={href}
+              whileHover={{ scale: 1.03 }}
+              whileFocus={{ scale: 1.03 }}
+              whileTap={{ scale: 0.97 }}
+            >
+              <Link
+                href={href}
+                className={`flex items-center gap-1 px-3 py-1 rounded-md transition-colors ${active ? "text-flora-leaf" : "text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"}`}
+                aria-current={active ? "page" : undefined}
+                aria-label={label}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span>{label}</span>
+              </Link>
+            </motion.li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add DesktopTopNav component to render nav items horizontally for desktop
- swap SidebarNav for DesktopTopNav in dashboard layout while keeping MobileNav for small screens

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d4358b888324969513d4caf370c2