### PR TITLE
Add quick stats and vitals strip to plant detail page

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -5,10 +5,12 @@ import dynamic from "next/dynamic"
 import { ToastProvider, useToast } from "@/components/Toast"
 import PlantDetailSkeleton from "./PlantDetailSkeleton"
 import HeroSection from "@/components/plant-detail/HeroSection"
+import QuickStats from "@/components/plant-detail/QuickStats"
 import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
 import Timeline from "@/components/plant-detail/Timeline"
 import Gallery from "@/components/plant-detail/Gallery"
 import CarePlan from "@/components/plant-detail/CarePlan"
+import VitalsStrip from "@/components/plant-detail/VitalsStrip"
 
 const WaterModal = dynamic(() => import("@/components/WaterModal"), {
   ssr: false,
@@ -277,6 +279,9 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               onAddNote={handleAddNote}
             />
             <div className="mt-8">
+              <QuickStats plant={plant} weather={weather} />
+            </div>
+            <div className="mt-8">
               {carePlanLoading ? (
                 <div className="rounded-xl p-6 bg-green-50 dark:bg-gray-800 text-center text-sm text-gray-500">
                   Loading care plan...
@@ -288,6 +293,9 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               ) : (
                 <CarePlan plan={carePlan} nickname={plant.nickname} />
               )}
+            </div>
+            <div className="mt-8">
+              <VitalsStrip plant={plant} weather={weather} />
             </div>
             <div className="mt-8">
               <AnalyticsPanel plant={plant} weather={weather} />

--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -7,7 +7,6 @@ import {
   type WaterEvent,
   type WeatherDay,
 } from '@/lib/plant-metrics'
-import VitalsSummary from './VitalsSummary'
 import type { Plant } from './types'
 import type { Weather } from '@/lib/weather'
 import EnvironmentBlock from './EnvironmentBlock'
@@ -142,7 +141,6 @@ export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) 
 
   return (
     <>
-      <VitalsSummary plant={plant} weather={weather} />
       <div className="mb-4 flex gap-2 md:hidden">
         {sections.map((s) => (
           <button

--- a/components/plant-detail/QuickStats.tsx
+++ b/components/plant-detail/QuickStats.tsx
@@ -50,11 +50,13 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
   const stats = [
     {
       icon: Droplet,
-      text: `${plant.lastWatered} (Last watered)`,
+      label: 'Last watered',
+      value: plant.lastWatered,
     },
     {
       icon: Calendar,
-      text: `${plant.nextDue}${
+      label: 'Next water',
+      value: `${plant.nextDue}${
         plant.recommendedWaterMl !== undefined
           ? ` (~${plant.recommendedWaterMl} ml)`
           : ''
@@ -62,30 +64,33 @@ export default function QuickStats({ plant, weather }: QuickStatsProps) {
     },
     {
       icon: Sprout,
-      text: `${calculateNextFeedDate(
+      label: 'Next feed',
+      value: calculateNextFeedDate(
         plant.lastFertilized,
         plant.nutrientLevel ?? 100,
-      )} (Next feed)`,
+      ),
     },
     {
       icon: Battery,
-      text: `${plant.hydration}% Hydration`,
+      label: 'Hydration',
+      value: `${plant.hydration}%`,
     },
     {
       icon: Activity,
-      text: `${stressLabel} Stress`,
+      label: 'Stress',
+      value: `${stressLabel} (${stressValue})`,
     },
   ]
 
   return (
     <ul className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-700 dark:text-gray-200">
-      {stats.map(({ icon: Icon, text }) => (
+      {stats.map(({ icon: Icon, label, value }) => (
         <li
-          key={text}
+          key={label}
           className="flex items-center gap-1 after:content-['|'] last:after:content-[''] after:mx-2 after:text-gray-300"
         >
           <Icon className="h-4 w-4" />
-          {text}
+          {label}: {value}
         </li>
       ))}
     </ul>

--- a/components/plant-detail/VitalsStrip.tsx
+++ b/components/plant-detail/VitalsStrip.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { Activity, Battery, Calendar } from 'lucide-react'
+import { calculateStressIndex } from '@/lib/plant-metrics'
+import type { Plant } from './types'
+import type { Weather } from '@/lib/weather'
+
+interface VitalsStripProps {
+  plant: Plant
+  weather: Weather | null
+}
+
+export default function VitalsStrip({ plant, weather }: VitalsStripProps) {
+  const stressValue = Math.round(
+    calculateStressIndex({
+      overdueDays: plant.status === 'Water overdue' ? 1 : 0,
+      hydration: plant.hydration,
+      temperature: weather?.temperature ?? 25,
+      light: 50,
+    }),
+  )
+  const stressLabel =
+    stressValue < 30 ? 'Low' : stressValue <= 70 ? 'Moderate' : 'High'
+
+  const vitals = [
+    { label: 'Stress', value: stressLabel, icon: Activity },
+    { label: 'Hydration', value: `${plant.hydration}%`, icon: Battery },
+    {
+      label: 'Next Water',
+      value: `${plant.nextDue}${plant.recommendedWaterMl !== undefined ? ` · ${plant.recommendedWaterMl}ml` : ''}`,
+      icon: Calendar,
+    },
+  ]
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {vitals.map(({ label, value, icon: Icon }) => (
+        <div
+          key={label}
+          className="flex items-center justify-between rounded-lg bg-gray-50 p-4 dark:bg-gray-800"
+        >
+          <span className="text-sm text-gray-500">{label}</span>
+          <span className="flex items-center gap-1 font-medium">
+            <Icon className="h-4 w-4 text-gray-400" />
+            {value}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- show quick stats after the hero on the plant detail page
- expand QuickStats component to label stress, hydration, and next care tasks

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d4bc5d688324805d59b5323feabb