### PR TITLE
feat: hover-expand sidebar

### DIFF
--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -2,46 +2,26 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { motion } from "framer-motion"
-import { ChevronLeft, ChevronRight } from "lucide-react"
 
+import Tooltip from "./Tooltip"
 import { navItems } from "./navItems"
 
-interface SidebarNavProps {
-  collapsed: boolean
-  toggle: () => void
-}
-
-export default function SidebarNav({ collapsed, toggle }: SidebarNavProps) {
+export default function SidebarNav() {
   const pathname = usePathname()
 
   return (
     <motion.aside
-      initial={false}
-      animate={{ width: collapsed ? 64 : 256 }}
-      className={`hidden md:flex flex-col bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 ${collapsed ? "p-2 items-center" : "p-6"} overflow-hidden`}
+      initial={{ width: 64 }}
+      animate={{ width: 64 }}
+      whileHover={{ width: 256 }}
+      className="group hidden md:flex flex-col bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 p-2 items-center hover:p-6 hover:items-start overflow-hidden"
     >
-      <button
-        id="sidebar-toggle"
-        onClick={toggle}
-        aria-label="Toggle sidebar"
-        aria-expanded={collapsed ? "false" : "true"}
-        aria-controls="sidebar-nav"
-        className="self-end mb-4 p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800"
-      >
-        {collapsed ? (
-          <ChevronRight className="h-4 w-4" />
-        ) : (
-          <ChevronLeft className="h-4 w-4" />
-        )}
-      </button>
       <nav
         id="sidebar-nav"
         role="navigation"
         aria-label="Sidebar navigation"
       >
-        <ul
-          className={`flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 ${collapsed ? "items-center" : ""}`}
-        >
+        <ul className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 items-center group-hover:items-start">
           {navItems.map(({ href, label, icon: Icon }) => {
             const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
             return (
@@ -53,12 +33,16 @@ export default function SidebarNav({ collapsed, toggle }: SidebarNavProps) {
               >
                 <Link
                   href={href}
-                  className={`flex items-center ${collapsed ? "justify-center px-0" : "px-2"} py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
+                  className={`relative flex items-center justify-center group-hover:justify-start px-0 group-hover:px-2 py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "before:absolute before:left-0 before:w-1 before:h-full before:bg-flora-leaf bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
                   aria-current={active ? "page" : undefined}
                   aria-label={label}
                 >
-                  <Icon className="h-5 w-5" aria-hidden="true" />
-                  {!collapsed && <span className="ml-2">{label}</span>}
+                  <Tooltip content={label}>
+                    <div className="flex items-center">
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                      <span className="ml-2 hidden group-hover:block">{label}</span>
+                    </div>
+                  </Tooltip>
                 </Link>
               </motion.li>
             )

--- a/components/navItems.ts
+++ b/components/navItems.ts
@@ -1,8 +1,0 @@
-import { Calendar, Home, FlaskConical, Notebook } from "lucide-react"
-
-export const navItems = [
-  { href: "/", label: "Today", icon: Calendar },
-  { href: "/rooms", label: "Rooms", icon: Home },
-  { href: "/science", label: "Science Panel", icon: FlaskConical },
-  { href: "/notebook", label: "Lab Notebook", icon: Notebook },
-]

--- a/components/navItems.tsx
+++ b/components/navItems.tsx
@@ -1,0 +1,32 @@
+import { type HTMLAttributes } from "react"
+
+export const navItems = [
+  {
+    href: "/",
+    label: "Today",
+    icon: ({ className }: HTMLAttributes<HTMLSpanElement>) => (
+      <span className={className}>📅</span>
+    ),
+  },
+  {
+    href: "/rooms",
+    label: "Rooms",
+    icon: ({ className }: HTMLAttributes<HTMLSpanElement>) => (
+      <span className={className}>🪴</span>
+    ),
+  },
+  {
+    href: "/science",
+    label: "Science Panel",
+    icon: ({ className }: HTMLAttributes<HTMLSpanElement>) => (
+      <span className={className}>🔬</span>
+    ),
+  },
+  {
+    href: "/notebook",
+    label: "Lab Notebook",
+    icon: ({ className }: HTMLAttributes<HTMLSpanElement>) => (
+      <span className={className}>📓</span>
+    ),
+  },
+]


### PR DESCRIPTION
## Summary
- hover-expand sidebar on desktop, with tooltip labels and active indicator
- swap nav icons for emoji icons

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60e5814148324a6b8d363765216a2