### PR TITLE
Remove default open state from plant detail sections

### DIFF
--- a/components/plant-detail/EnvironmentBlock.tsx
+++ b/components/plant-detail/EnvironmentBlock.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import EnvRow from '@/components/EnvRow'
 import ChartCard from '@/components/ChartCard'
@@ -29,9 +30,15 @@ interface EnvironmentBlockProps {
 }
 
 export default function EnvironmentBlock({ env, envChartData }: EnvironmentBlockProps) {
+  const [open, setOpen] = useState(false)
   return (
-    <details id="environment" open>
-      <summary className="text-lg font-semibold cursor-pointer">Environment</summary>
+    <details id="environment" open={open}>
+      <summary
+        className="text-lg font-semibold cursor-pointer"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Environment
+      </summary>
       <p className="text-sm text-gray-500 mb-4">
         Temperature, humidity, and vapor pressure deficit readings.
       </p>

--- a/components/plant-detail/HydrationBlock.tsx
+++ b/components/plant-detail/HydrationBlock.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import ChartCard from '@/components/ChartCard'
 import type { Plant } from './types'
@@ -37,9 +38,15 @@ export default function HydrationBlock({
   showWater,
   setShowWater,
 }: HydrationBlockProps) {
+  const [open, setOpen] = useState(false)
   return (
-    <details id="hydration" open>
-      <summary className="text-lg font-semibold cursor-pointer">Hydration & Nutrients</summary>
+    <details id="hydration" open={open}>
+      <summary
+        className="text-lg font-semibold cursor-pointer"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Hydration & Nutrients
+      </summary>
       <p className="text-sm text-gray-500 mb-4">
         Nutrient levels and water balance.
       </p>

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import ChartCard from '@/components/ChartCard'
 import { type StressDatum } from '@/lib/plant-metrics'
@@ -22,9 +23,15 @@ interface StressBlockProps {
 }
 
 export default function StressBlock({ plant, weather, stressData }: StressBlockProps) {
+  const [open, setOpen] = useState(false)
   return (
-    <details id="plant-health" open>
-      <summary className="text-lg font-semibold cursor-pointer">Plant Health</summary>
+    <details id="plant-health" open={open}>
+      <summary
+        className="text-lg font-semibold cursor-pointer"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Plant Health
+      </summary>
       <p className="text-sm text-gray-500 mb-4">
         Stress index overview and overall health radar.
       </p>


### PR DESCRIPTION
## Summary
- stop `details` blocks from auto-expanding in StressBlock, EnvironmentBlock, and HydrationBlock
- add React state to toggle each section open or closed on summary click

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6141310e8832485d2e2e8dd984342