### PR TITLE
style: customize details summary indicators

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,3 +9,21 @@ body {
 h1, h2, h3 {
   @apply font-semibold text-gray-800;
 }
+
+/* Hide default disclosure triangle on summary */
+summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Custom indicator for summary elements */
+summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform 0.2s ease-in-out;
+}
+
+/* Rotate indicator when details is open */
+details[open] > summary::before {
+  transform: rotate(90deg);
+}

--- a/components/plant-detail/EnvironmentBlock.tsx
+++ b/components/plant-detail/EnvironmentBlock.tsx
@@ -34,7 +34,7 @@ export default function EnvironmentBlock({ env, envChartData }: EnvironmentBlock
   return (
     <details id="environment" open={open}>
       <summary
-        className="text-lg font-semibold cursor-pointer"
+        className="flex items-center gap-1 text-lg font-semibold cursor-pointer py-2 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2"
         onClick={() => setOpen((o) => !o)}
       >
         Environment

--- a/components/plant-detail/HydrationBlock.tsx
+++ b/components/plant-detail/HydrationBlock.tsx
@@ -42,7 +42,7 @@ export default function HydrationBlock({
   return (
     <details id="hydration" open={open}>
       <summary
-        className="text-lg font-semibold cursor-pointer"
+        className="flex items-center gap-1 text-lg font-semibold cursor-pointer py-2 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2"
         onClick={() => setOpen((o) => !o)}
       >
         Hydration & Nutrients

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -27,7 +27,7 @@ export default function StressBlock({ plant, weather, stressData }: StressBlockP
   return (
     <details id="plant-health" open={open}>
       <summary
-        className="text-lg font-semibold cursor-pointer"
+        className="flex items-center gap-1 text-lg font-semibold cursor-pointer py-2 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2"
         onClick={() => setOpen((o) => !o)}
       >
         Plant Health


### PR DESCRIPTION
## Summary
- hide default details marker and add rotating arrow indicator
- unify summary styling across plant detail blocks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b61522a7dc83249da06720e42ee725