### PR TITLE
Refactor sidebar to fixed icon-only width

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,17 +1,13 @@
 "use client"
 
-import { useState } from "react"
 import SidebarNav from "@/components/SidebarNav"
 import MobileNav from "@/components/MobileNav"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const [collapsed, setCollapsed] = useState(false)
-  const toggle = () => setCollapsed((prev) => !prev)
-
   return (
     <div className="flex min-h-screen">
-      <SidebarNav collapsed={collapsed} toggle={toggle} />
-      <div className="flex-1 flex flex-col pb-16 md:pb-0">
+      <SidebarNav />
+      <div className="flex-1 flex flex-col pb-16 md:pb-0 md:pl-4">
         {children}
         <MobileNav />
       </div>

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -1,70 +1,36 @@
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { motion } from "framer-motion"
-import { ChevronLeft, ChevronRight } from "lucide-react"
 
 import { navItems } from "./navItems"
 
-interface SidebarNavProps {
-  collapsed: boolean
-  toggle: () => void
-}
-
-export default function SidebarNav({ collapsed, toggle }: SidebarNavProps) {
+export default function SidebarNav() {
   const pathname = usePathname()
 
   return (
-    <motion.aside
-      initial={false}
-      animate={{ width: collapsed ? 64 : 256 }}
-      className={`hidden md:flex flex-col bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 ${collapsed ? "p-2 items-center" : "p-6"} overflow-hidden`}
+    <aside
+      className="hidden md:flex w-14 flex-col items-center bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 border-r border-gray-200 dark:border-gray-700 p-2"
     >
-      <button
-        id="sidebar-toggle"
-        onClick={toggle}
-        aria-label="Toggle sidebar"
-        aria-expanded={collapsed ? "false" : "true"}
-        aria-controls="sidebar-nav"
-        className="self-end mb-4 p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800"
-      >
-        {collapsed ? (
-          <ChevronRight className="h-4 w-4" />
-        ) : (
-          <ChevronLeft className="h-4 w-4" />
-        )}
-      </button>
-      <nav
-        id="sidebar-nav"
-        role="navigation"
-        aria-label="Sidebar navigation"
-      >
-        <ul
-          className={`flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 ${collapsed ? "items-center" : ""}`}
-        >
+      <nav id="sidebar-nav" role="navigation" aria-label="Sidebar navigation">
+        <ul className="flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200 items-center">
           {navItems.map(({ href, label, icon: Icon }) => {
             const active = href === "/" ? pathname === "/" : pathname.startsWith(href)
             return (
-              <motion.li
-                key={href}
-                whileHover={{ scale: 1.03 }}
-                whileFocus={{ scale: 1.03 }}
-                whileTap={{ scale: 0.97 }}
-              >
+              <li key={href}>
                 <Link
                   href={href}
-                  className={`flex items-center ${collapsed ? "justify-center px-0" : "px-2"} py-1 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
+                  className={`flex justify-center p-2 rounded transition-colors duration-200 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-800 dark:hover:to-gray-700 ${active ? "bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-700 text-flora-leaf" : ""}`}
                   aria-current={active ? "page" : undefined}
                   aria-label={label}
                 >
                   <Icon className="h-5 w-5" aria-hidden="true" />
-                  {!collapsed && <span className="ml-2">{label}</span>}
+                  <span className="sr-only">{label}</span>
                 </Link>
-              </motion.li>
+              </li>
             )
           })}
         </ul>
       </nav>
-    </motion.aside>
+    </aside>
   )
 }


### PR DESCRIPTION
## Summary
- simplify `SidebarNav` to a fixed, narrow icon-only bar
- drop collapse logic from dashboard layout and adjust content spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b616d09edc832483a6f81a41c0f08a