### PR TITLE
Rename fertilization section to fertilizer

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -15,7 +15,7 @@ describe('CarePlan', () => {
       humidity: 'Moderate humidity',
       temperature: '65-75°F',
       soil: 'Well-draining potting mix',
-      fertilization: 'Feed monthly',
+      fertilizer: 'Feed monthly',
       pruning: 'Trim as needed',
       pests: 'Watch for aphids',
     }
@@ -29,12 +29,12 @@ describe('CarePlan', () => {
       humidity: 'wind',
       temperature: 'thermometer',
       soil: 'land-plot',
-      fertilization: 'sprout',
+      fertilizer: 'sprout',
       pruning: 'scissors',
       pests: 'bug',
     }
     const labelMap: Record<string, string> = {
-      fertilization: 'Fertilizer',
+      fertilizer: 'Fertilizer',
     }
 
     for (const [key, text] of Object.entries(plan)) {

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -40,7 +40,7 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
     { key: 'humidity', label: 'Humidity', icon: Wind },
     { key: 'temperature', label: 'Temperature', icon: Thermometer },
     { key: 'soil', label: 'Soil', icon: LandPlot },
-    { key: 'fertilization', label: 'Fertilizer', icon: Sprout },
+    { key: 'fertilizer', label: 'Fertilizer', icon: Sprout },
     { key: 'pruning', label: 'Pruning', icon: Scissors },
     { key: 'pests', label: 'Pests', icon: Bug },
   ]


### PR DESCRIPTION
## Summary
- use `fertilizer` key for care-plan sections instead of `fertilization`
- update CarePlan tests to align with new fertilizer label

## Testing
- `pnpm test` *(fails: /usr/bin/pnpm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b618d85a24832480185d1e11571806