### PR TITLE
Refactor care plan layout

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import CarePlan from '../plant-detail/CarePlan'
 
 describe('CarePlan', () => {
@@ -7,7 +7,7 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections with icons and collapsible details', () => {
+  it('renders provided plan sections with icons', () => {
     const plan = {
       overview: 'General care overview',
       light: 'Bright, indirect light',
@@ -33,14 +33,14 @@ describe('CarePlan', () => {
       pruning: 'scissors',
       pests: 'bug',
     }
-    const labelMap: Record<string, string> = {
-      fertilizer: 'Fertilizer',
-    }
+    fireEvent.click(screen.getByText(/Additional care/i))
 
     for (const [key, text] of Object.entries(plan)) {
-      const label = labelMap[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
-      const button = screen.getByRole('button', { name: new RegExp(label, 'i') })
-      const svg = button.querySelector('svg')
+      const label = key.charAt(0).toUpperCase() + key.slice(1)
+      const heading = screen.getByRole('heading', {
+        name: new RegExp(label, 'i'),
+      })
+      const svg = heading.querySelector('svg')
       expect(svg).toBeInTheDocument()
       expect(svg).toHaveClass(`lucide-${iconMap[key]}`)
       expect(screen.getByText(text)).toBeInTheDocument()

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState } from 'react'
 import Image from 'next/image'
 import {
   Sun,
@@ -55,58 +54,29 @@ export default function CarePlan({ plan, nickname, photo }: CarePlanProps) {
     .filter((s): s is Section => s !== null)
 
   const hasPlan = !!planObj
-  const [openSections, setOpenSections] = useState<string[]>(
-    sections.map((s) => s.key)
-  )
 
   const overviewSection = sections.find((s) => s.key === 'Overview')
-  const leftSections = sections.filter((s) =>
-    ['Light Needs', 'Watering Frequency', 'Humidity', 'Temperature'].includes(s.key)
+  const primaryOrder = ['Light Needs', 'Watering Frequency', 'Fertilizer']
+  const primarySections: Section[] = primaryOrder
+    .map((k) => sections.find((s) => s.key === k)!)
+    .filter((s): s is Section => Boolean(s))
+  const remainingPrimary = sections.filter(
+    (s) => !['Overview', 'Pests', 'Pruning', ...primaryOrder].includes(s.key)
   )
-  const rightSections = sections.filter((s) =>
-    ['Soil', 'Fertilizer', 'Pruning', 'Pests'].includes(s.key)
+  primarySections.push(...remainingPrimary)
+  const secondarySections = sections.filter((s) =>
+    ['Pests', 'Pruning'].includes(s.key)
   )
 
-  const toggleSection = (key: string) => {
-    setOpenSections((prev) =>
-      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
-    )
-  }
-
-  const allOpen = openSections.length === sections.length
-  const toggleAll = () =>
-    setOpenSections(allOpen ? [] : sections.map((s) => s.key))
-
-  const renderSection = ({ key, icon: Icon, text }: Section) => {
-    const isOpen = openSections.includes(key)
-    const guidance =
-      key === 'Light Needs'
-        ? 'Prefers bright, indirect sunlight.'
-        : key === 'Watering Frequency'
-          ? 'Water when the top inch of soil is dry.'
-          : null
-    return (
-      <div key={key} className="border rounded-md">
-        <button
-          type="button"
-          className="w-full flex items-center p-2 text-left"
-          onClick={() => toggleSection(key)}
-          title={guidance ?? undefined}
-        >
-          <Icon className="w-5 h-5 mr-2 flex-shrink-0" />
-          <span className="font-medium">
-            {key}
-            {guidance && (
-              <small aria-hidden="true" className="block ml-2 text-gray-500">
-                {guidance}
-              </small>
-            )}
-          </span>
-        </button>
-        {isOpen && <div className="p-2 pt-0 text-sm">{text}</div>}
-      </div>
-    )
-  }
+  const renderSection = ({ key, icon: Icon, text }: Section) => (
+    <section key={key} className="space-y-1">
+      <h3 className="flex items-center font-medium">
+        <Icon className="w-5 h-5 mr-2" />
+        {key}
+      </h3>
+      <p className="text-sm">{text}</p>
+    </section>
+  )
 
   return (
     <section className="rounded-xl overflow-hidden bg-green-50 dark:bg-gray-800">
@@ -138,21 +108,23 @@ export default function CarePlan({ plan, nickname, photo }: CarePlanProps) {
           </p>
         ) : sections.length > 0 ? (
           <>
-            <div className="flex justify-end mb-2">
-              <button
-                type="button"
-                className="text-xs text-blue-600 dark:text-blue-400"
-                onClick={toggleAll}
-              >
-                {allOpen ? 'Collapse all' : 'Show all'}
-              </button>
-            </div>
             {overviewSection && (
-              <div className="mb-2">{renderSection(overviewSection)}</div>
+              <div className="mb-4">{renderSection(overviewSection)}</div>
             )}
-            <div className="grid grid-cols-1 md:grid-cols-2 md:gap-4">
-              <div className="space-y-2">{leftSections.map(renderSection)}</div>
-              <div className="space-y-2">{rightSections.map(renderSection)}</div>
+            <div className="space-y-4">
+              <div className="space-y-4">
+                {primarySections.map(renderSection)}
+              </div>
+              {secondarySections.length > 0 && (
+                <details className="pt-4 border-t">
+                  <summary className="cursor-pointer text-sm font-medium">
+                    Additional care
+                  </summary>
+                  <div className="mt-2 space-y-4">
+                    {secondarySections.map(renderSection)}
+                  </div>
+                </details>
+              )}
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- simplify CarePlan sections into primary and secondary blocks
- tuck pests and pruning under Additional care collapse
- update tests for new layout

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6475413a88324a94d798223c895b6