### PR TITLE
Group primary care info and simplify care plan layout

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -19,9 +19,10 @@ describe('CarePlan', () => {
       pruning: 'Trim as needed',
       pests: 'Watch for aphids',
     }
-
     render(<CarePlan plan={plan} nickname="Delilah" />)
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
+    expect(screen.getByText(/More care tips/i)).toBeInTheDocument()
+
     const iconMap: Record<string, string> = {
       overview: 'book-open',
       light: 'sun',
@@ -39,8 +40,10 @@ describe('CarePlan', () => {
 
     for (const [key, text] of Object.entries(plan)) {
       const label = labelMap[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
-      const button = screen.getByRole('button', { name: new RegExp(label, 'i') })
-      const svg = button.querySelector('svg')
+      const heading = screen.getByRole('heading', {
+        name: new RegExp(label, 'i'),
+      })
+      const svg = heading.querySelector('svg')
       expect(svg).toBeInTheDocument()
       expect(svg).toHaveClass(`lucide-${iconMap[key]}`)
       expect(screen.getByText(text)).toBeInTheDocument()

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+// The CarePlan component presents plant care guidance grouped by importance.
+// Primary care details (light, water, fertilizer) are surfaced directly while
+// secondary tips like pests and pruning are tucked into a collapsible section
+// to reduce visual clutter.
 import {
   Sun,
   Droplet,
@@ -52,58 +55,30 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
     .filter((s): s is Section => s !== null)
 
   const hasPlan = !!planObj
-  const [openSections, setOpenSections] = useState<string[]>(
-    sections.map((s) => s.key)
-  )
 
   const overviewSection = sections.find((s) => s.key === 'Overview')
-  const leftSections = sections.filter((s) =>
-    ['Light Needs', 'Watering Frequency', 'Humidity', 'Temperature'].includes(s.key)
-  )
-  const rightSections = sections.filter((s) =>
-    ['Soil', 'Fertilizer', 'Pruning', 'Pests'].includes(s.key)
+
+  const primarySections = sections.filter((s) =>
+    ['Light Needs', 'Watering Frequency', 'Fertilizer'].includes(s.key)
   )
 
-  const toggleSection = (key: string) => {
-    setOpenSections((prev) =>
-      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
-    )
-  }
+  const secondarySections = sections.filter((s) =>
+    ['Pests', 'Pruning'].includes(s.key)
+  )
 
-  const allOpen = openSections.length === sections.length
-  const toggleAll = () =>
-    setOpenSections(allOpen ? [] : sections.map((s) => s.key))
+  const otherSections = sections.filter((s) =>
+    ![...primarySections, ...secondarySections].includes(s) && s.key !== 'Overview'
+  )
 
-  const renderSection = ({ key, icon: Icon, text }: Section) => {
-    const isOpen = openSections.includes(key)
-    const guidance =
-      key === 'Light Needs'
-        ? 'Prefers bright, indirect sunlight.'
-        : key === 'Watering Frequency'
-          ? 'Water when the top inch of soil is dry.'
-          : null
-    return (
-      <div key={key} className="border rounded-md">
-        <button
-          type="button"
-          className="w-full flex items-center p-2 text-left"
-          onClick={() => toggleSection(key)}
-          title={guidance ?? undefined}
-        >
-          <Icon className="w-4 h-4 mr-2 flex-shrink-0 text-gray-500 dark:text-gray-400" />
-          <span className="font-medium">
-            {key}
-            {guidance && (
-              <small aria-hidden="true" className="block ml-2 text-gray-500">
-                {guidance}
-              </small>
-            )}
-          </span>
-        </button>
-        {isOpen && <div className="p-2 pt-0 text-sm">{text}</div>}
-      </div>
-    )
-  }
+  const renderSection = ({ key, icon: Icon, text }: Section) => (
+    <section key={key} className="space-y-1">
+      <h3 className="flex items-center font-medium">
+        <Icon className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" />
+        {key}
+      </h3>
+      <p className="text-sm">{text}</p>
+    </section>
+  )
 
   return (
     <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
@@ -114,22 +89,25 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
         </p>
       ) : sections.length > 0 ? (
         <>
-          <div className="flex justify-end mb-2">
-            <button
-              type="button"
-              className="text-xs text-blue-600 dark:text-blue-400"
-              onClick={toggleAll}
-            >
-              {allOpen ? 'Collapse all' : 'Show all'}
-            </button>
-          </div>
           {overviewSection && (
-            <div className="mb-2">{renderSection(overviewSection)}</div>
+            <div className="mb-4">{renderSection(overviewSection)}</div>
           )}
-          <div className="grid grid-cols-1 md:grid-cols-2 md:gap-4">
-            <div className="space-y-2">{leftSections.map(renderSection)}</div>
-            <div className="space-y-2">{rightSections.map(renderSection)}</div>
-          </div>
+          {primarySections.length > 0 && (
+            <div className="space-y-4">{primarySections.map(renderSection)}</div>
+          )}
+          {otherSections.length > 0 && (
+            <div className="mt-4 space-y-4">{otherSections.map(renderSection)}</div>
+          )}
+          {secondarySections.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm font-medium text-blue-600 dark:text-blue-400">
+                More care tips
+              </summary>
+              <div className="mt-2 space-y-4">
+                {secondarySections.map(renderSection)}
+              </div>
+            </details>
+          )}
         </>
       ) : (
         <pre className="whitespace-pre-line text-sm">


### PR DESCRIPTION
## Summary
- Group light, water, and fertilizer info into a primary care block
- Tuck pests and pruning into a collapsible "More care tips" section
- Replace card UI with simple section containers for cleaner layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64b3c39648324a393151efca0b3a1