### PR TITLE
Add floating care action buttons

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -9,6 +9,7 @@ import AnalyticsPanel from "@/components/plant-detail/AnalyticsPanel"
 import Timeline from "@/components/plant-detail/Timeline"
 import Gallery from "@/components/plant-detail/Gallery"
 import CarePlan from "@/components/plant-detail/CarePlan"
+import FloatingActions from "@/components/plant-detail/FloatingActions"
 
 const WaterModal = dynamic(() => import("@/components/WaterModal"), {
   ssr: false,
@@ -301,6 +302,13 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           </>
         )}
       </div>
+      {plant && (
+        <FloatingActions
+          onWater={handleWater}
+          onFertilize={handleFertilize}
+          onAddNote={handleAddNote}
+        />
+      )}
       <WaterModal
         isOpen={waterOpen}
         onClose={() => setWaterOpen(false)}

--- a/components/plant-detail/FloatingActions.tsx
+++ b/components/plant-detail/FloatingActions.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Droplet, Sprout, FileText } from 'lucide-react'
+
+interface FloatingActionsProps {
+  onWater: () => void
+  onFertilize: () => void
+  onAddNote: () => void
+}
+
+export default function FloatingActions({
+  onWater,
+  onFertilize,
+  onAddNote,
+}: FloatingActionsProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 100)
+    }
+    handleScroll()
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  if (!visible) return null
+
+  return (
+    <div
+      className="fixed z-50 flex flex-col gap-3"
+      style={{
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
+        right: 'calc(env(safe-area-inset-right, 0px) + 1rem)',
+      }}
+    >
+      <button
+        onClick={onWater}
+        aria-label="Water plant"
+        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-blue-300 text-sm text-blue-700 bg-white/90 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400 dark:bg-gray-800/90 transition-colors"
+      >
+        <span className="pointer-events-none absolute inset-0 rounded-full bg-blue-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
+        <Droplet className="h-4 w-4" />
+        Water
+      </button>
+      <button
+        onClick={onFertilize}
+        aria-label="Fertilize plant"
+        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-green-300 text-sm text-green-700 bg-white/90 hover:bg-green-50 dark:border-green-400 dark:text-green-400 dark:bg-gray-800/90 transition-colors"
+      >
+        <span className="pointer-events-none absolute inset-0 rounded-full bg-green-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
+        <Sprout className="h-4 w-4" />
+        Feed
+      </button>
+      <button
+        onClick={onAddNote}
+        aria-label="Add note to plant"
+        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-purple-300 text-sm text-purple-700 bg-white/90 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-400 dark:bg-gray-800/90 transition-colors"
+      >
+        <span className="pointer-events-none absolute inset-0 rounded-full bg-purple-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
+        <FileText className="h-4 w-4" />
+        Add Note
+      </button>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add FloatingActions component for water/feed/note quick actions
- show floating actions when scrolled down the plant detail page

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b64ce512708324b7d839b52efa28b6