### PR TITLE
feat: allow editing plant details

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -22,6 +22,10 @@ const NoteModal = dynamic(() => import("@/components/NoteModal"), {
   ssr: false,
   loading: () => null,
 })
+const EditPlantModal = dynamic(() => import("@/components/EditPlantModal"), {
+  ssr: false,
+  loading: () => null,
+})
 import type { Plant, PlantEvent } from "@/components/plant-detail/types"
 import { getWeatherForUser, type Weather } from "@/lib/weather"
 import { samplePlants } from "@/lib/plants"
@@ -35,6 +39,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
   const [waterOpen, setWaterOpen] = useState(false)
   const [fertilizeOpen, setFertilizeOpen] = useState(false)
   const [noteOpen, setNoteOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
   const toast = useToast()
   const [weather, setWeather] = useState<Weather | null>(null)
   const [offline, setOffline] = useState(false)
@@ -69,6 +74,10 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
 
   function handleAddNote() {
     setNoteOpen(true)
+  }
+
+  function handleEdit() {
+    setEditOpen(true)
   }
 
   function handleWaterSubmit(amount: string) {
@@ -120,6 +129,40 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
         : prev
     )
     toast("Note added")
+  }
+
+  function handleEditSubmit({
+    nickname,
+    species,
+    photo,
+  }: {
+    nickname: string
+    species: string
+    photo: string
+  }) {
+    setPlant((prev) =>
+      prev
+        ? {
+            ...prev,
+            nickname,
+            species,
+            photos: photo ? [photo, ...prev.photos.slice(1)] : prev.photos,
+          }
+        : prev,
+    )
+
+    fetch(`/api/plants/${params.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ nickname, species, photo }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed")
+        return res.json()
+      })
+      .then((data) => setPlant(data))
+      .then(() => toast("Plant updated"))
+      .catch(() => toast("Failed to update plant"))
   }
 
   async function fetchWeatherForPlant(): Promise<Weather | null> {
@@ -275,6 +318,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
               onWater={handleWater}
               onFertilize={handleFertilize}
               onAddNote={handleAddNote}
+              onEdit={handleEdit}
             />
             <div className="mt-8">
               {carePlanLoading ? (
@@ -316,6 +360,14 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
         onClose={() => setNoteOpen(false)}
         onSubmit={handleNoteSubmit}
       />
+      {plant && (
+        <EditPlantModal
+          isOpen={editOpen}
+          onClose={() => setEditOpen(false)}
+          plant={plant}
+          onSubmit={handleEditSubmit}
+        />
+      )}
     </main>
   )
 }

--- a/app/api/plants/[id]/route.ts
+++ b/app/api/plants/[id]/route.ts
@@ -11,3 +11,20 @@ export async function GET(
   }
   return NextResponse.json(plant)
 }
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const plant = samplePlants[params.id as keyof typeof samplePlants]
+  if (!plant) {
+    return NextResponse.json({ error: 'Plant not found' }, { status: 404 })
+  }
+  const { nickname, species, photo } = await request.json()
+  if (typeof nickname === 'string') plant.nickname = nickname
+  if (typeof species === 'string') plant.species = species
+  if (typeof photo === 'string' && photo) {
+    plant.photos = [photo, ...plant.photos.slice(1)]
+  }
+  return NextResponse.json(plant)
+}

--- a/components/EditPlantModal.tsx
+++ b/components/EditPlantModal.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Modal from './Modal'
+import type { Plant } from './plant-detail/types'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  plant: Plant
+  onSubmit: (data: { nickname: string; species: string; photo: string }) => void
+}
+
+export default function EditPlantModal({ isOpen, onClose, plant, onSubmit }: Props) {
+  const [nickname, setNickname] = useState(plant.nickname)
+  const [species, setSpecies] = useState(plant.species)
+  const [photo, setPhoto] = useState(plant.photos?.[0] ?? '')
+
+  useEffect(() => {
+    if (isOpen) {
+      setNickname(plant.nickname)
+      setSpecies(plant.species)
+      setPhoto(plant.photos?.[0] ?? '')
+    }
+  }, [isOpen, plant])
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    onSubmit({ nickname, species, photo })
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <h2 className="h2 mb-4">Edit Plant</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="block text-sm">
+          Nickname
+          <input
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            className="mt-1 w-full rounded border px-2 py-1"
+          />
+        </label>
+        <label className="block text-sm">
+          Species
+          <input
+            value={species}
+            onChange={(e) => setSpecies(e.target.value)}
+            className="mt-1 w-full rounded border px-2 py-1"
+          />
+        </label>
+        <label className="block text-sm">
+          Photo URL
+          <input
+            value={photo}
+            onChange={(e) => setPhoto(e.target.value)}
+            className="mt-1 w-full rounded border px-2 py-1"
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 rounded border"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-3 py-1 rounded bg-orange-600 text-white hover:bg-orange-700"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+

--- a/components/__tests__/HeroSection.test.tsx
+++ b/components/__tests__/HeroSection.test.tsx
@@ -26,6 +26,7 @@ function renderHero(hydration: number) {
       onWater={() => {}}
       onFertilize={() => {}}
       onAddNote={() => {}}
+      onEdit={() => {}}
     />,
   )
 }
@@ -47,5 +48,10 @@ describe('HeroSection hydration bar', () => {
     const bar = progress.querySelector('div') as HTMLElement
     expect(bar).toHaveClass('from-alert')
     expect(bar).toHaveClass('to-alert-red')
+  })
+
+  it('renders an Edit button', () => {
+    renderHero(80)
+    expect(screen.getByRole('button', { name: /edit plant/i })).toBeInTheDocument()
   })
 })

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { Droplet, Sprout, FileText } from 'lucide-react'
+import { Droplet, Sprout, FileText, Edit } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { getHydrationProgress } from '@/components/PlantCard'
@@ -15,6 +15,7 @@ interface HeroSectionProps {
   onWater: () => void
   onFertilize: () => void
   onAddNote: () => void
+  onEdit: () => void
 }
 
 export default function HeroSection({
@@ -23,6 +24,7 @@ export default function HeroSection({
   onWater,
   onFertilize,
   onAddNote,
+  onEdit,
 }: HeroSectionProps) {
   const progress = getHydrationProgress(plant.hydration)
   const [nextWaterDue, setNextWaterDue] = useState(plant.nextDue)
@@ -94,6 +96,15 @@ export default function HeroSection({
           <span className="pointer-events-none absolute inset-0 rounded-full bg-purple-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
           <FileText className="h-4 w-4" />
           Add Note
+        </button>
+        <button
+          onClick={onEdit}
+          aria-label="Edit plant"
+          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-orange-300 text-sm text-orange-700 bg-white/30 hover:bg-orange-50 dark:border-orange-400 dark:text-orange-400 transition-colors"
+        >
+          <span className="pointer-events-none absolute inset-0 rounded-full bg-orange-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
+          <Edit className="h-4 w-4" />
+          Edit
         </button>
       </div>
       <div className="flex flex-wrap justify-center sm:justify-start gap-2 text-sm">


### PR DESCRIPTION
## Summary
- add Edit button to plant hero section
- enable plant nickname, species, and photo changes via new EditPlantModal
- update plant API to persist edits

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b64cd1cb2883248f9b2baef4d1cc0f