### PR TITLE
Add hydration status labels to progress bars

### DIFF
--- a/components/PlantCard.tsx
+++ b/components/PlantCard.tsx
@@ -25,11 +25,13 @@ type PlantCardProps = {
 
 export function getHydrationProgress(hydration: number) {
   const pct = Math.max(0, Math.min(100, Math.round(hydration)))
-  const barClass =
-    pct < 60
-      ? 'bg-gradient-to-r from-alert to-alert-red'
-      : 'bg-gradient-to-r from-fertilize to-water'
-  return { pct, barClass }
+  if (pct < 30) {
+    return { pct, colorClass: 'bg-alert-red', status: 'Low' }
+  }
+  if (pct <= 70) {
+    return { pct, colorClass: 'bg-alert', status: 'Moderate' }
+  }
+  return { pct, colorClass: 'bg-water', status: 'High' }
 }
 
 export default function PlantCard({
@@ -43,7 +45,7 @@ export default function PlantCard({
   photo,
   onMarkDone,
 }: PlantCardProps) {
-  const { pct, barClass } = getHydrationProgress(hydration)
+  const { pct, colorClass, status: hydrationStatus } = getHydrationProgress(hydration)
   const statusColor =
     status === 'Water overdue'
       ? 'bg-alert-red text-white'
@@ -83,17 +85,18 @@ export default function PlantCard({
         <span className={`text-xs font-semibold px-[var(--space-sm)] py-[calc(var(--space-xs)/2)] rounded-full ${statusColor}`}>{status}</span>
       </div>
       {note && <p className="text-xs text-gray-600 dark:text-gray-400">{note}</p>}
-      <div
-        className="w-full bg-gray-200 rounded-full h-2 mt-[var(--space-sm)] overflow-hidden"
-        role="progressbar"
-        aria-valuenow={pct}
-        aria-valuemin={0}
-        aria-valuemax={100}
-      >
+      <div className="flex items-center gap-[var(--space-sm)] mt-[var(--space-sm)]" aria-live="polite">
         <div
-          className={`h-2 ${barClass}`}
-          style={{ width: `${pct}%` }}
-        />
+          className="w-full bg-gray-200 rounded-full h-2 overflow-hidden"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={`${pct}% hydration`}
+        >
+          <div className={`h-2 ${colorClass}`} style={{ width: `${pct}%` }} />
+        </div>
+        <span className="text-xs text-gray-600 dark:text-gray-400">{hydrationStatus}</span>
       </div>
       <div className="flex items-center justify-between mt-[var(--space-sm)]">
         <div className="text-xs text-gray-500 dark:text-gray-400 flex flex-col gap-[var(--space-xs)]">

--- a/components/__tests__/HeroSection.test.tsx
+++ b/components/__tests__/HeroSection.test.tsx
@@ -32,22 +32,22 @@ function renderHero(hydration: number) {
 }
 
 describe('HeroSection hydration bar', () => {
-  it('uses fertilize to water gradient when hydration is at least 60', () => {
-    renderHero(60)
+  it('shows water color and High label when hydration is above 70', () => {
+    renderHero(80)
     const progress = screen.getByRole('progressbar', { name: /hydration/i })
     const bar = progress.querySelector('div') as HTMLElement
-    expect(bar).toHaveClass('from-fertilize')
-    expect(bar).toHaveClass('to-water')
-    expect(progress).toHaveAttribute('aria-valuenow', '60')
-    expect(progress).toHaveAttribute('aria-valuetext', '60% hydration')
+    expect(bar).toHaveClass('bg-water')
+    expect(progress).toHaveAttribute('aria-valuenow', '80')
+    expect(progress).toHaveAttribute('aria-valuetext', '80% hydration')
+    expect(screen.getByText(/high/i)).toBeInTheDocument()
   })
 
-  it('uses alert gradient when hydration is below 60', () => {
-    renderHero(59)
+  it('shows alert-red color and Low label when hydration is below 30', () => {
+    renderHero(20)
     const progress = screen.getByRole('progressbar', { name: /hydration/i })
     const bar = progress.querySelector('div') as HTMLElement
-    expect(bar).toHaveClass('from-alert')
-    expect(bar).toHaveClass('to-alert-red')
+    expect(bar).toHaveClass('bg-alert-red')
+    expect(screen.getByText(/low/i)).toBeInTheDocument()
   })
 
   it('renders an Edit button', () => {

--- a/components/__tests__/PlantCard.test.tsx
+++ b/components/__tests__/PlantCard.test.tsx
@@ -22,6 +22,7 @@ describe('PlantCard', () => {
     expect(progress).toHaveAttribute('aria-valuenow', '55')
     expect(progress).toHaveAttribute('aria-valuemin', '0')
     expect(progress).toHaveAttribute('aria-valuemax', '100')
+    expect(screen.getByText(/moderate/i)).toBeInTheDocument()
 
     expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/fern.jpg')
     expect(screen.getByText(/fern/i)).toBeInTheDocument()

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -112,20 +112,22 @@ export default function HeroSection({
           {plant.status}
         </span>
       </div>
-      <div
-        className="w-full bg-gray-200 rounded-full h-2"
-        role="progressbar"
-        aria-label="Hydration"
-        aria-valuenow={progress.pct}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuetext={`${progress.pct}% hydration`}
-      >
+      <div className="flex items-center gap-2" aria-live="polite">
         <div
-          className={`h-2 rounded-full ${progress.barClass}`}
-          style={{ width: `${progress.pct}%` }}
-        />
-        <span className="sr-only">{`${progress.pct}% hydration`}</span>
+          className="w-full bg-gray-200 rounded-full h-2"
+          role="progressbar"
+          aria-label="Hydration"
+          aria-valuenow={progress.pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={`${progress.pct}% hydration`}
+        >
+          <div
+            className={`h-2 rounded-full ${progress.colorClass}`}
+            style={{ width: `${progress.pct}%` }}
+          />
+        </div>
+        <span className="text-sm text-gray-700 dark:text-gray-300">{progress.status}</span>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- map hydration ranges to semantic colors and labels
- display visible hydration status label beside progress bar with aria-live updates
- adjust components and tests for new progress bar logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64df3d42c83249b57aab37bb36cd7