### PR TITLE
Refactor CarePlan with reusable CareTipCard component

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -7,7 +7,7 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections with icons and collapsible details', () => {
+  it('renders provided plan sections with icons', () => {
     const plan = {
       overview: 'General care overview',
       light: 'Bright, indirect light',
@@ -21,7 +21,6 @@ describe('CarePlan', () => {
     }
     render(<CarePlan plan={plan} nickname="Delilah" />)
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
-    expect(screen.getByText(/More care tips/i)).toBeInTheDocument()
 
     const iconMap: Record<string, string> = {
       overview: 'book-open',
@@ -35,11 +34,19 @@ describe('CarePlan', () => {
       pests: 'bug',
     }
     const labelMap: Record<string, string> = {
+      overview: 'Overview',
+      light: 'Light Needs',
+      water: 'Watering Frequency',
+      humidity: 'Humidity',
+      temperature: 'Temperature',
+      soil: 'Soil',
       fertilizer: 'Fertilizer',
+      pruning: 'Pruning',
+      pests: 'Pests',
     }
 
     for (const [key, text] of Object.entries(plan)) {
-      const label = labelMap[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
+      const label = labelMap[key]
       const heading = screen.getByRole('heading', {
         name: new RegExp(label, 'i'),
       })

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-// The CarePlan component presents plant care guidance grouped by importance.
-// Primary care details (light, water, fertilizer) are surfaced directly while
-// secondary tips like pests and pruning are tucked into a collapsible section
-// to reduce visual clutter.
+// The CarePlan component presents plant care guidance as digestible tips.
+// Each care aspect is shown in a card with an icon and description to keep
+// information scannable and easy to read.
 import {
   Sun,
   Droplet,
@@ -16,6 +15,7 @@ import {
   BookOpen,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import CareTipCard from './CareTipCard'
 
 interface CarePlanProps {
   plan?: string | Record<string, string> | null
@@ -56,59 +56,24 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
 
   const hasPlan = !!planObj
 
-  const overviewSection = sections.find((s) => s.key === 'Overview')
-
-  const primarySections = sections.filter((s) =>
-    ['Light Needs', 'Watering Frequency', 'Fertilizer'].includes(s.key)
-  )
-
-  const secondarySections = sections.filter((s) =>
-    ['Pests', 'Pruning'].includes(s.key)
-  )
-
-  const otherSections = sections.filter((s) =>
-    ![...primarySections, ...secondarySections].includes(s) && s.key !== 'Overview'
-  )
-
-  const renderSection = ({ key, icon: Icon, text }: Section) => (
-    <section key={key} className="space-y-1">
-      <h3 className="flex items-center font-medium">
-        <Icon className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" />
-        {key}
-      </h3>
-      <p className="text-sm">{text}</p>
-    </section>
-  )
-
   return (
     <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
-      <h2 className="h2 mb-4">Care Plan for {nickname}</h2>
+      <h2 className="h2 mb-6">Care Plan for {nickname}</h2>
       {!hasPlan ? (
         <p className="text-sm text-gray-600 dark:text-gray-400">
           No care plan available
         </p>
       ) : sections.length > 0 ? (
-        <>
-          {overviewSection && (
-            <div className="mb-4">{renderSection(overviewSection)}</div>
-          )}
-          {primarySections.length > 0 && (
-            <div className="space-y-4">{primarySections.map(renderSection)}</div>
-          )}
-          {otherSections.length > 0 && (
-            <div className="mt-4 space-y-4">{otherSections.map(renderSection)}</div>
-          )}
-          {secondarySections.length > 0 && (
-            <details className="mt-4">
-              <summary className="cursor-pointer text-sm font-medium text-blue-600 dark:text-blue-400">
-                More care tips
-              </summary>
-              <div className="mt-2 space-y-4">
-                {secondarySections.map(renderSection)}
-              </div>
-            </details>
-          )}
-        </>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {sections.map(({ key, icon, text }) => (
+            <CareTipCard
+              key={key}
+              icon={icon}
+              title={key}
+              description={text}
+            />
+          ))}
+        </div>
       ) : (
         <pre className="whitespace-pre-line text-sm">
           {typeof plan === 'string' ? plan : JSON.stringify(plan, null, 2)}

--- a/components/plant-detail/CareTipCard.tsx
+++ b/components/plant-detail/CareTipCard.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { LucideIcon } from 'lucide-react'
+
+interface CareTipCardProps {
+  icon: LucideIcon
+  title: string
+  description: string
+}
+
+export default function CareTipCard({ icon: Icon, title, description }: CareTipCardProps) {
+  return (
+    <section className="p-6 md:p-8 rounded-lg bg-white dark:bg-gray-800 space-y-2">
+      <h3 className="h3 flex items-center gap-2">
+        <Icon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+        {title}
+      </h3>
+      <p className="text-sm leading-relaxed md:leading-loose">{description}</p>
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add CareTipCard component with icon, title, description and responsive spacing
- render CarePlan sections as grid of CareTipCard elements
- update CarePlan tests for new layout

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6507f8d7c832483eff9d7dfd47834