### PR TITLE
Expose secondary care tips in CarePlan

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -7,7 +7,7 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections with icons and collapsible details', () => {
+  it('renders provided plan sections with icons and secondary tip cards', () => {
     const plan = {
       overview: 'General care overview',
       light: 'Bright, indirect light',
@@ -21,7 +21,6 @@ describe('CarePlan', () => {
     }
     render(<CarePlan plan={plan} nickname="Delilah" />)
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
-    expect(screen.getByText(/More care tips/i)).toBeInTheDocument()
 
     const iconMap: Record<string, string> = {
       overview: 'book-open',
@@ -48,6 +47,10 @@ describe('CarePlan', () => {
       expect(svg).toHaveClass(`lucide-${iconMap[key]}`)
       expect(screen.getByText(text)).toBeInTheDocument()
     }
+
+    const pestsHeading = screen.getByRole('heading', { name: /Pests/i })
+    const card = pestsHeading.closest('div')
+    expect(card).toHaveClass('border')
   })
 })
 

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -2,8 +2,8 @@
 
 // The CarePlan component presents plant care guidance grouped by importance.
 // Primary care details (light, water, fertilizer) are surfaced directly while
-// secondary tips like pests and pruning are tucked into a collapsible section
-// to reduce visual clutter.
+// secondary tips like pests and pruning appear afterward in subtle bordered cards
+// for clear separation.
 import {
   Sun,
   Droplet,
@@ -99,14 +99,16 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
             <div className="mt-4 space-y-4">{otherSections.map(renderSection)}</div>
           )}
           {secondarySections.length > 0 && (
-            <details className="mt-4">
-              <summary className="cursor-pointer text-sm font-medium text-blue-600 dark:text-blue-400">
-                More care tips
-              </summary>
-              <div className="mt-2 space-y-4">
-                {secondarySections.map(renderSection)}
-              </div>
-            </details>
+            <div className="mt-4 space-y-4">
+              {secondarySections.map((section) => (
+                <div
+                  key={section.key}
+                  className="p-4 rounded-lg border border-gray-200 dark:border-gray-700"
+                >
+                  {renderSection(section)}
+                </div>
+              ))}
+            </div>
           )}
         </>
       ) : (


### PR DESCRIPTION
## Summary
- show secondary care plan tips without a collapsible section
- wrap secondary tips in subtle bordered cards for clarity
- update CarePlan tests for new layout

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6505b63f08324b18fff8ce569348e