### PR TITLE
Refactor CarePlan with reusable CareTipCard grid

### DIFF
--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -7,7 +7,7 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections with icons and secondary tip cards', () => {
+  it('renders provided plan sections as cards with icons', () => {
     const plan = {
       overview: 'General care overview',
       light: 'Bright, indirect light',
@@ -22,6 +22,9 @@ describe('CarePlan', () => {
     render(<CarePlan plan={plan} nickname="Delilah" />)
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
 
+    const grid = screen.getByTestId('care-tip-grid')
+    expect(grid).toHaveClass('grid', 'grid-cols-1', 'md:grid-cols-2', 'gap-6')
+
     const iconMap: Record<string, string> = {
       overview: 'book-open',
       light: 'sun',
@@ -33,24 +36,28 @@ describe('CarePlan', () => {
       pruning: 'scissors',
       pests: 'bug',
     }
+
     const labelMap: Record<string, string> = {
+      overview: 'Overview',
+      light: 'Light Needs',
+      water: 'Watering Frequency',
+      humidity: 'Humidity',
+      temperature: 'Temperature',
+      soil: 'Soil',
       fertilizer: 'Fertilizer',
+      pruning: 'Pruning',
+      pests: 'Pests',
     }
 
     for (const [key, text] of Object.entries(plan)) {
-      const label = labelMap[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
       const heading = screen.getByRole('heading', {
-        name: new RegExp(label, 'i'),
+        name: new RegExp(labelMap[key], 'i'),
       })
       const svg = heading.querySelector('svg')
       expect(svg).toBeInTheDocument()
       expect(svg).toHaveClass(`lucide-${iconMap[key]}`)
       expect(screen.getByText(text)).toBeInTheDocument()
     }
-
-    const pestsHeading = screen.getByRole('heading', { name: /Pests/i })
-    const card = pestsHeading.closest('div')
-    expect(card).toHaveClass('border')
   })
 })
 

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -16,6 +16,7 @@ import {
   BookOpen,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import CareTipCard from './CareTipCard'
 
 interface CarePlanProps {
   plan?: string | Record<string, string> | null
@@ -24,6 +25,7 @@ interface CarePlanProps {
 
 interface Section {
   key: string
+  title: string
   icon: LucideIcon
   text: string
 }
@@ -50,67 +52,33 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
   const sections: Section[] = sectionsConfig
     .map(({ key, label, icon }) => {
       const text = planObj?.[key]
-      return text ? { key: label, icon, text } : null
+      return text ? { key, title: label, icon, text } : null
     })
     .filter((s): s is Section => s !== null)
 
   const hasPlan = !!planObj
 
-  const overviewSection = sections.find((s) => s.key === 'Overview')
-
-  const primarySections = sections.filter((s) =>
-    ['Light Needs', 'Watering Frequency', 'Fertilizer'].includes(s.key)
-  )
-
-  const secondarySections = sections.filter((s) =>
-    ['Pests', 'Pruning'].includes(s.key)
-  )
-
-  const otherSections = sections.filter((s) =>
-    ![...primarySections, ...secondarySections].includes(s) && s.key !== 'Overview'
-  )
-
-  const renderSection = ({ key, icon: Icon, text }: Section) => (
-    <section key={key} className="space-y-1">
-      <h3 className="flex items-center h3">
-        <Icon className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" />
-        {key}
-      </h3>
-      <p className="body-text">{text}</p>
-    </section>
-  )
-
   return (
     <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
-      <h2 className="h2 mb-4">Care Plan for {nickname}</h2>
+      <h2 className="h2 mb-6">Care Plan for {nickname}</h2>
       {!hasPlan ? (
         <p className="body-text text-gray-600 dark:text-gray-400">
           No care plan available
         </p>
       ) : sections.length > 0 ? (
-        <>
-          {overviewSection && (
-            <div className="mb-4">{renderSection(overviewSection)}</div>
-          )}
-          {primarySections.length > 0 && (
-            <div className="space-y-4">{primarySections.map(renderSection)}</div>
-          )}
-          {otherSections.length > 0 && (
-            <div className="mt-4 space-y-4">{otherSections.map(renderSection)}</div>
-          )}
-          {secondarySections.length > 0 && (
-            <div className="mt-4 space-y-4">
-              {secondarySections.map((section) => (
-                <div
-                  key={section.key}
-                  className="p-4 rounded-lg border border-gray-200 dark:border-gray-700"
-                >
-                  {renderSection(section)}
-                </div>
-              ))}
-            </div>
-          )}
-        </>
+        <div
+          data-testid="care-tip-grid"
+          className="grid grid-cols-1 md:grid-cols-2 gap-6"
+        >
+          {sections.map(({ key, title, icon, text }) => (
+            <CareTipCard
+              key={key}
+              icon={icon}
+              title={title}
+              description={text}
+            />
+          ))}
+        </div>
       ) : (
         <pre className="whitespace-pre-line body-text">
           {typeof plan === 'string' ? plan : JSON.stringify(plan, null, 2)}

--- a/components/plant-detail/CareTipCard.tsx
+++ b/components/plant-detail/CareTipCard.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import type { LucideIcon } from 'lucide-react'
+
+interface CareTipCardProps {
+  icon: LucideIcon
+  title: string
+  description: string
+}
+
+export default function CareTipCard({
+  icon: Icon,
+  title,
+  description,
+}: CareTipCardProps) {
+  return (
+    <div className="p-4 sm:p-6 space-y-2 rounded-xl border border-gray-200 dark:border-gray-700">
+      <h3 className="h3 flex items-center gap-2">
+        <Icon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+        {title}
+      </h3>
+      <p className="body-text leading-relaxed md:leading-loose">{description}</p>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add responsive `CareTipCard` component for care tips with icons
- render all care plan sections via `CareTipCard` in a 2-column grid
- adjust tests to cover new layout and icon rendering

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6521a47b48324b0e5a3fd0b582560