### PR TITLE
Revamp plant detail layout and UX

### DIFF
--- a/app/(dashboard)/plants/[id]/page.tsx
+++ b/app/(dashboard)/plants/[id]/page.tsx
@@ -313,14 +313,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           </div>
         ) : (
           <>
-            <HeroSection
-              plant={plant}
-              weather={weather}
-              onWater={handleWater}
-              onFertilize={handleFertilize}
-              onAddNote={handleAddNote}
-              onEdit={handleEdit}
-            />
+            <HeroSection plant={plant} weather={weather} />
             <div className="mt-8">
               {carePlanLoading ? (
                 <div className="rounded-xl p-6 bg-green-50 dark:bg-gray-800 text-center text-sm text-gray-500">
@@ -355,6 +348,7 @@ export function PlantDetailContent({ params }: { params: { id: string } }) {
           onWater={handleWater}
           onFertilize={handleFertilize}
           onAddNote={handleAddNote}
+          onEdit={handleEdit}
         />
       )}
       <WaterModal

--- a/components/ChartCard.tsx
+++ b/components/ChartCard.tsx
@@ -15,12 +15,11 @@ export default function ChartCard({
   children,
   variant = 'secondary',
 }: ChartCardProps) {
-  const base =
-    'snap-start rounded-lg p-4 border border-transparent dark:border-transparent'
+  const base = 'snap-start rounded-lg p-4 border shadow-sm'
   const variantClasses =
     variant === 'primary'
-      ? 'min-w-full md:min-w-0 bg-white dark:bg-gray-900'
-      : 'flex-shrink-0 min-w-[260px] md:min-w-0 bg-gray-50 dark:bg-gray-800'
+      ? 'min-w-full md:min-w-0 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700'
+      : 'flex-shrink-0 min-w-[260px] md:min-w-0 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
 
   return (
     <div className={`${base} ${variantClasses}`}>

--- a/components/__tests__/CarePlan.test.tsx
+++ b/components/__tests__/CarePlan.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import CarePlan from '../plant-detail/CarePlan'
 
 describe('CarePlan', () => {
@@ -7,7 +8,7 @@ describe('CarePlan', () => {
     expect(screen.getByText(/No care plan available/i)).toBeInTheDocument()
   })
 
-  it('renders provided plan sections as cards with icons', () => {
+  it('renders primary sections and toggles secondary tips', async () => {
     const plan = {
       overview: 'General care overview',
       light: 'Bright, indirect light',
@@ -22,42 +23,15 @@ describe('CarePlan', () => {
     render(<CarePlan plan={plan} nickname="Delilah" />)
     expect(screen.getByText(/Care Plan for Delilah/i)).toBeInTheDocument()
 
-    const grid = screen.getByTestId('care-tip-grid')
-    expect(grid).toHaveClass('grid', 'grid-cols-1', 'md:grid-cols-2', 'gap-6')
+    // primary sections visible
+    expect(screen.getByText(/Light Needs/i)).toBeInTheDocument()
+    expect(screen.getByText(/Watering Frequency/i)).toBeInTheDocument()
+    expect(screen.getByText(/Pests/i)).not.toBeVisible()
 
-    const iconMap: Record<string, string> = {
-      overview: 'book-open',
-      light: 'sun',
-      water: 'droplet',
-      humidity: 'wind',
-      temperature: 'thermometer',
-      soil: 'land-plot',
-      fertilizer: 'sprout',
-      pruning: 'scissors',
-      pests: 'bug',
-    }
+    const toggle = screen.getByText(/More care tips/i)
+    await userEvent.click(toggle)
 
-    const labelMap: Record<string, string> = {
-      overview: 'Overview',
-      light: 'Light Needs',
-      water: 'Watering Frequency',
-      humidity: 'Humidity',
-      temperature: 'Temperature',
-      soil: 'Soil',
-      fertilizer: 'Fertilizer',
-      pruning: 'Pruning',
-      pests: 'Pests',
-    }
-
-    for (const [key, text] of Object.entries(plan)) {
-      const heading = screen.getByRole('heading', {
-        name: new RegExp(labelMap[key], 'i'),
-      })
-      const svg = heading.querySelector('svg')
-      expect(svg).toBeInTheDocument()
-      expect(svg).toHaveClass(`lucide-${iconMap[key]}`)
-      expect(screen.getByText(text)).toBeInTheDocument()
-    }
+    expect(screen.getByText(/Pests/i)).toBeVisible()
   })
 })
 

--- a/components/__tests__/HeroSection.test.tsx
+++ b/components/__tests__/HeroSection.test.tsx
@@ -23,10 +23,6 @@ function renderHero(hydration: number) {
     <HeroSection
       plant={{ ...basePlant, hydration }}
       weather={null}
-      onWater={() => {}}
-      onFertilize={() => {}}
-      onAddNote={() => {}}
-      onEdit={() => {}}
     />,
   )
 }
@@ -50,8 +46,4 @@ describe('HeroSection hydration bar', () => {
     expect(screen.getByText(/low/i)).toBeInTheDocument()
   })
 
-  it('renders an Edit button', () => {
-    renderHero(80)
-    expect(screen.getByRole('button', { name: /edit plant/i })).toBeInTheDocument()
-  })
 })

--- a/components/plant-detail/CarePlan.tsx
+++ b/components/plant-detail/CarePlan.tsx
@@ -58,6 +58,29 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
 
   const hasPlan = !!planObj
 
+  const colorMap: Record<string, { card: string; icon: string }> = {
+    water: {
+      card: 'border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950',
+      icon: 'text-blue-600',
+    },
+    light: {
+      card: 'border-yellow-200 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950',
+      icon: 'text-yellow-600',
+    },
+    humidity: {
+      card: 'border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950',
+      icon: 'text-green-600',
+    },
+    soil: {
+      card: 'border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950',
+      icon: 'text-emerald-600',
+    },
+  }
+
+  const primaryKeys = ['light', 'water', 'soil']
+  const primary = sections.filter((s) => primaryKeys.includes(s.key))
+  const secondary = sections.filter((s) => !primaryKeys.includes(s.key))
+
   return (
     <section className="rounded-xl p-6 bg-green-50 dark:bg-gray-800">
       <h2 className="h2 mb-6">Care Plan for {nickname}</h2>
@@ -66,19 +89,42 @@ export default function CarePlan({ plan, nickname }: CarePlanProps) {
           No care plan available
         </p>
       ) : sections.length > 0 ? (
-        <div
-          data-testid="care-tip-grid"
-          className="grid grid-cols-1 md:grid-cols-2 gap-6"
-        >
-          {sections.map(({ key, title, icon, text }) => (
-            <CareTipCard
-              key={key}
-              icon={icon}
-              title={title}
-              description={text}
-            />
-          ))}
-        </div>
+        <>
+          <div
+            data-testid="care-tip-grid"
+            className="grid grid-cols-1 md:grid-cols-2 gap-6"
+          >
+            {primary.map(({ key, title, icon, text }) => (
+              <CareTipCard
+                key={key}
+                icon={icon}
+                title={title}
+                description={text}
+                className={colorMap[key]?.card}
+                iconClass={colorMap[key]?.icon}
+              />
+            ))}
+          </div>
+          {secondary.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm text-gray-600 dark:text-gray-300">
+                More care tips
+              </summary>
+              <div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-6">
+                {secondary.map(({ key, title, icon, text }) => (
+                  <CareTipCard
+                    key={key}
+                    icon={icon}
+                    title={title}
+                    description={text}
+                    className={colorMap[key]?.card}
+                    iconClass={colorMap[key]?.icon}
+                  />
+                ))}
+              </div>
+            </details>
+          )}
+        </>
       ) : (
         <pre className="whitespace-pre-line body-text">
           {typeof plan === 'string' ? plan : JSON.stringify(plan, null, 2)}

--- a/components/plant-detail/CareTipCard.tsx
+++ b/components/plant-detail/CareTipCard.tsx
@@ -6,17 +6,21 @@ interface CareTipCardProps {
   icon: LucideIcon
   title: string
   description: string
+  className?: string
+  iconClass?: string
 }
 
 export default function CareTipCard({
   icon: Icon,
   title,
   description,
+  className = 'border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
+  iconClass = 'text-gray-500 dark:text-gray-400',
 }: CareTipCardProps) {
   return (
-    <div className="p-4 sm:p-6 space-y-2 rounded-xl border border-gray-200 dark:border-gray-700">
+    <div className={`p-4 sm:p-6 space-y-2 rounded-xl ${className}`}>
       <h3 className="h3 flex items-center gap-2">
-        <Icon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+        <Icon className={`w-5 h-5 ${iconClass}`} />
         {title}
       </h3>
       <p className="body-text leading-relaxed md:leading-loose">{description}</p>

--- a/components/plant-detail/FloatingActions.tsx
+++ b/components/plant-detail/FloatingActions.tsx
@@ -1,37 +1,25 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { Droplet, Sprout, FileText } from 'lucide-react'
+import { Droplet, Sprout, FileText, Edit } from 'lucide-react'
 
 interface FloatingActionsProps {
   onWater: () => void
   onFertilize: () => void
   onAddNote: () => void
+  onEdit: () => void
 }
 
 export default function FloatingActions({
   onWater,
   onFertilize,
   onAddNote,
+  onEdit,
 }: FloatingActionsProps) {
-  const [visible, setVisible] = useState(false)
-
-  useEffect(() => {
-    const handleScroll = () => {
-      setVisible(window.scrollY > 100)
-    }
-    handleScroll()
-    window.addEventListener('scroll', handleScroll, { passive: true })
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
-
-  if (!visible) return null
-
   return (
     <div
       className="fixed z-50 flex flex-col gap-3"
       style={{
-        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
+        top: 'calc(env(safe-area-inset-top, 0px) + 1rem)',
         right: 'calc(env(safe-area-inset-right, 0px) + 1rem)',
       }}
     >
@@ -61,6 +49,15 @@ export default function FloatingActions({
         <span className="pointer-events-none absolute inset-0 rounded-full bg-purple-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
         <FileText className="h-4 w-4" />
         Add Note
+      </button>
+      <button
+        onClick={onEdit}
+        aria-label="Edit plant"
+        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-orange-300 text-sm text-orange-700 bg-white/90 hover:bg-orange-50 dark:border-orange-400 dark:text-orange-400 dark:bg-gray-800/90 transition-colors"
+      >
+        <span className="pointer-events-none absolute inset-0 rounded-full bg-orange-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
+        <Edit className="h-4 w-4" />
+        Edit
       </button>
     </div>
   )

--- a/components/plant-detail/Gallery.tsx
+++ b/components/plant-detail/Gallery.tsx
@@ -165,7 +165,7 @@ export default function Gallery({
         </p>
       )}
       <div
-        className={`grid grid-cols-3 gap-4 ${
+        className={`grid grid-cols-2 sm:grid-cols-3 gap-4 ${
           dragActive ? 'ring-2 ring-green-500' : ''
         }`}
         onDragOver={onDragOver}
@@ -176,21 +176,21 @@ export default function Gallery({
           <button
             key={i}
             onClick={() => setOpenIndex(i)}
-            className="group relative aspect-square w-full focus:outline-none"
+            className="group relative w-full focus:outline-none"
             aria-label={`View image ${i + 1} of ${length}`}
           >
-            <Image
-              src={src}
-              alt={`${nickname} photo ${i + 1}`}
-              fill
-              sizes="200px"
-              className="object-cover rounded-lg"
-              loading="lazy"
-            />
-            <span className="absolute inset-0 flex items-end justify-start rounded-lg bg-black/0 hover:bg-black/40 transition-colors">
-              <span className="m-1 rounded px-1 text-xs text-white opacity-0 group-hover:opacity-100">
-                Photo {i + 1}
-              </span>
+            <div className="relative aspect-square w-full overflow-hidden rounded-lg shadow-sm">
+              <Image
+                src={src}
+                alt={`${nickname} photo ${i + 1}`}
+                fill
+                sizes="200px"
+                className="object-cover"
+                loading="lazy"
+              />
+            </div>
+            <span className="absolute bottom-1 left-1 rounded bg-black/50 px-1 text-xs text-white opacity-0 group-hover:opacity-100">
+              Photo {i + 1}
             </span>
           </button>
         ))}

--- a/components/plant-detail/HeroSection.tsx
+++ b/components/plant-detail/HeroSection.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import Image from 'next/image'
-import { Droplet, Sprout, FileText, Edit } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
 import { formatDistanceToNow } from 'date-fns'
 import { getHydrationProgress } from '@/components/PlantCard'
 import QuickStats from './QuickStats'
@@ -12,27 +12,15 @@ import type { Weather } from '@/lib/weather'
 interface HeroSectionProps {
   plant: Plant
   weather: Weather | null
-  onWater: () => void
-  onFertilize: () => void
-  onAddNote: () => void
-  onEdit: () => void
 }
 
-export default function HeroSection({
-  plant,
-  weather,
-  onWater,
-  onFertilize,
-  onAddNote,
-  onEdit,
-}: HeroSectionProps) {
+export default function HeroSection({ plant, weather }: HeroSectionProps) {
   const progress = getHydrationProgress(plant.hydration)
   const [nextWaterDue, setNextWaterDue] = useState(plant.nextDue)
 
   useEffect(() => {
     setNextWaterDue(plant.nextDue)
   }, [plant.nextDue])
-
 
   const nextWaterDate = new Date(`${nextWaterDue} ${new Date().getFullYear()}`)
   const nextTaskText = `Needs water ${formatDistanceToNow(nextWaterDate, {
@@ -42,6 +30,8 @@ export default function HeroSection({
       ? ` (~${plant.recommendedWaterMl} ml)`
       : ''
   }`
+
+  const microDetails = `Last watered ${plant.lastWatered} • Pot ${plant.potSize}cm • ${plant.status}`
 
   return (
     <section className="space-y-6">
@@ -60,58 +50,17 @@ export default function HeroSection({
             <span className="text-gray-500 dark:text-gray-400">No photo</span>
           </div>
         )}
+        <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/20 to-black/0" />
         <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 via-black/0 p-4 sm:p-6">
           <h1 className="h1 font-serif text-white">{plant.nickname}</h1>
           <p className="text-lg italic text-white/80">{plant.species}</p>
-          <p className="mt-2 text-base text-white/90">{nextTaskText}</p>
+          <p className="mt-1 text-sm text-white/70">{microDetails}</p>
         </div>
       </div>
 
-      <QuickStats plant={plant} weather={weather} />
-
-      <div className="flex flex-wrap justify-center sm:justify-start gap-3">
-        <button
-          onClick={onWater}
-          aria-label="Water plant"
-          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-blue-300 text-sm text-blue-700 bg-white/30 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400 transition-colors"
-        >
-          <span className="pointer-events-none absolute inset-0 rounded-full bg-blue-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-          <Droplet className="h-4 w-4" />
-          Water
-        </button>
-        <button
-          onClick={onFertilize}
-          aria-label="Fertilize plant"
-          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-green-300 text-sm text-green-700 bg-white/30 hover:bg-green-50 dark:border-green-400 dark:text-green-400 transition-colors"
-        >
-          <span className="pointer-events-none absolute inset-0 rounded-full bg-green-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-          <Sprout className="h-4 w-4" />
-          Feed
-        </button>
-        <button
-          onClick={onAddNote}
-          aria-label="Add note to plant"
-          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-purple-300 text-sm text-purple-700 bg-white/30 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-400 transition-colors"
-        >
-          <span className="pointer-events-none absolute inset-0 rounded-full bg-purple-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-          <FileText className="h-4 w-4" />
-          Add Note
-        </button>
-        <button
-          onClick={onEdit}
-          aria-label="Edit plant"
-          className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-orange-300 text-sm text-orange-700 bg-white/30 hover:bg-orange-50 dark:border-orange-400 dark:text-orange-400 transition-colors"
-        >
-          <span className="pointer-events-none absolute inset-0 rounded-full bg-orange-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-          <Edit className="h-4 w-4" />
-          Edit
-        </button>
-      </div>
-      <div className="flex flex-wrap justify-center sm:justify-start gap-2 text-sm">
-        <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full font-medium">
-          {plant.status}
-        </span>
-      </div>
+      <p className="text-xl font-semibold" aria-live="polite">
+        {nextTaskText}
+      </p>
       <div className="flex items-center gap-2" aria-live="polite">
         <div
           className="w-full bg-gray-200 rounded-full h-2"
@@ -122,13 +71,17 @@ export default function HeroSection({
           aria-valuemax={100}
           aria-valuetext={`${progress.pct}% hydration`}
         >
-          <div
+          <motion.div
             className={`h-2 rounded-full ${progress.colorClass}`}
-            style={{ width: `${progress.pct}%` }}
+            animate={{ width: `${progress.pct}%` }}
+            transition={{ type: 'spring', stiffness: 120, damping: 20 }}
           />
         </div>
         <span className="text-sm text-gray-700 dark:text-gray-300">{progress.status}</span>
       </div>
+
+      <QuickStats plant={plant} weather={weather} />
     </section>
   )
 }
+

--- a/components/plant-detail/Timeline.tsx
+++ b/components/plant-detail/Timeline.tsx
@@ -10,16 +10,19 @@ const EVENT_TYPES = {
     icon: Droplet,
     label: 'Water',
     badge: 'bg-blue-100 text-blue-700',
+    emoji: '💧',
   },
   fertilize: {
     icon: Sprout,
     label: 'Feed',
     badge: 'bg-green-100 text-green-700',
+    emoji: '🌱',
   },
   note: {
     icon: FileText,
     label: 'Note',
     badge: 'bg-yellow-100 text-yellow-700',
+    emoji: '📝',
   },
 } as const
 
@@ -46,9 +49,7 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
   const processed = events
     ?.filter((e): e is PlantEvent => e !== null && e !== undefined)
     .filter((e) => filter === 'all' || e.type === filter)
-    .sort(
-      (a, b) => eventDate(b.date).getTime() - eventDate(a.date).getTime(),
-    )
+    .sort((a, b) => eventDate(b.date).getTime() - eventDate(a.date).getTime())
 
   const grouped = processed?.reduce((acc, e) => {
     const weekStart = startOfWeek(eventDate(e.date))
@@ -85,14 +86,12 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
         ))}
       </div>
       {!weeks.length ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400">
-          No activity yet.
-        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
       ) : (
         <div className="space-y-6">
           {weeks.map((week, index) => {
             const weekDate = parse(week, 'yyyy-MM-dd', new Date())
-            const weekEvents = grouped[week]
+            const weekEvents = grouped![week]
             return (
               <div key={week}>
                 <h3 className="h3 mb-2">
@@ -109,7 +108,6 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
                     const type =
                       EVENT_TYPES[e.type as keyof typeof EVENT_TYPES] ??
                       EVENT_TYPES.note
-                    const Icon = type.icon
                     const open = expandedId === e.id
                     const preview =
                       e.note && e.note.length > 80
@@ -117,10 +115,8 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
                         : e.note
                     return (
                       <li key={e.id} className="mb-6 ml-6">
-                        <span
-                          className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full ${type.badge}`}
-                        >
-                          <Icon className="w-4 h-4" />
+                        <span className="absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full bg-white shadow ring-1 ring-gray-200 dark:bg-gray-700 dark:ring-gray-600">
+                          {type.emoji}
                         </span>
                         <button
                           type="button"
@@ -131,24 +127,26 @@ export default function Timeline({ events }: { events: PlantEvent[] }) {
                           }
                           className="text-left w-full"
                         >
-                          <time className="text-sm text-gray-700 dark:text-gray-300">
-                            {formatDistanceToNow(eventDate(e.date), {
-                              addSuffix: true,
-                            })}
-                          </time>
-                          <span
-                            className={`ml-2 px-2 py-0.5 rounded-full text-xs font-medium ${type.badge}`}
-                          >
-                            {type.label}
-                          </span>
-                          {e.type === 'note' && (
-                            <div
-                              className="mt-2 p-3 rounded-lg bg-gray-50 dark:bg-gray-800 text-sm overflow-hidden transition-all duration-300"
-                              style={{ maxHeight: open ? '200px' : '48px' }}
+                          <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-800">
+                            <time className="text-sm text-gray-700 dark:text-gray-300">
+                              {formatDistanceToNow(eventDate(e.date), {
+                                addSuffix: true,
+                              })}
+                            </time>
+                            <span
+                              className={`ml-2 px-2 py-0.5 rounded-full text-xs font-medium ${type.badge}`}
                             >
-                              {open ? e.note : preview}
-                            </div>
-                          )}
+                              {type.label}
+                            </span>
+                            {e.type === 'note' && (
+                              <div
+                                className="mt-2 text-sm overflow-hidden transition-all duration-300"
+                                style={{ maxHeight: open ? '200px' : '48px' }}
+                              >
+                                {open ? e.note : preview}
+                              </div>
+                            )}
+                          </div>
                         </button>
                       </li>
                     )


### PR DESCRIPTION
## Summary
- Add gradient overlays, micro-details, and animated hydration bar to plant hero
- Introduce persistent floating action bar and color-coded care plan with collapsible tips
- Restyle timeline and gallery for a more polished, journal-like experience

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b65557c7d08324b86664f839e1b162