### PR TITLE
feat: add floating action menu

### DIFF
--- a/components/plant-detail/FloatingActions.tsx
+++ b/components/plant-detail/FloatingActions.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Droplet, Sprout, FileText, Edit } from 'lucide-react'
+import { useState } from 'react'
+import { Droplet, Sprout, FileText, Edit, Plus } from 'lucide-react'
 
 interface FloatingActionsProps {
   onWater: () => void
@@ -15,51 +16,80 @@ export default function FloatingActions({
   onAddNote,
   onEdit,
 }: FloatingActionsProps) {
+  const [open, setOpen] = useState(false)
+
   return (
     <div
-      className="fixed z-50 flex flex-col gap-3"
+      className="fixed z-50"
       style={{
         top: 'calc(env(safe-area-inset-top, 0px) + 1rem)',
         right: 'calc(env(safe-area-inset-right, 0px) + 1rem)',
       }}
     >
-      <button
-        onClick={onWater}
-        aria-label="Water plant"
-        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-blue-300 text-sm text-blue-700 bg-white/90 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400 dark:bg-gray-800/90 transition-colors"
-      >
-        <span className="pointer-events-none absolute inset-0 rounded-full bg-blue-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-        <Droplet className="h-4 w-4" />
-        Water
-      </button>
-      <button
-        onClick={onFertilize}
-        aria-label="Fertilize plant"
-        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-green-300 text-sm text-green-700 bg-white/90 hover:bg-green-50 dark:border-green-400 dark:text-green-400 dark:bg-gray-800/90 transition-colors"
-      >
-        <span className="pointer-events-none absolute inset-0 rounded-full bg-green-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-        <Sprout className="h-4 w-4" />
-        Feed
-      </button>
-      <button
-        onClick={onAddNote}
-        aria-label="Add note to plant"
-        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-purple-300 text-sm text-purple-700 bg-white/90 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-400 dark:bg-gray-800/90 transition-colors"
-      >
-        <span className="pointer-events-none absolute inset-0 rounded-full bg-purple-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-        <FileText className="h-4 w-4" />
-        Add Note
-      </button>
-      <button
-        onClick={onEdit}
-        aria-label="Edit plant"
-        className="relative group flex items-center gap-1 px-4 py-1 rounded-full border border-orange-300 text-sm text-orange-700 bg-white/90 hover:bg-orange-50 dark:border-orange-400 dark:text-orange-400 dark:bg-gray-800/90 transition-colors"
-      >
-        <span className="pointer-events-none absolute inset-0 rounded-full bg-orange-200/60 opacity-0 group-hover:opacity-40 group-hover:animate-[ping_0.6s_ease-out] group-focus:opacity-40 group-focus:animate-[ping_0.6s_ease-out]" />
-        <Edit className="h-4 w-4" />
-        Edit
-      </button>
+      <div className="relative">
+        <button
+          onClick={() => setOpen((o) => !o)}
+          aria-label="Toggle plant actions"
+          aria-expanded={open}
+          className={[
+            'flex h-12 w-12 items-center justify-center rounded-full',
+            'bg-teal-600 text-white shadow-lg transition-transform',
+            'hover:rotate-90 focus:outline-none focus-visible:ring',
+          ].join(' ')}
+        >
+          <Plus className="h-6 w-6" />
+        </button>
+        <div
+          className={`absolute right-0 mt-3 flex flex-col items-end gap-2 transition-all duration-200 ${
+            open ? 'opacity-100 translate-y-0' : 'pointer-events-none opacity-0 -translate-y-2'
+          }`}
+        >
+          <button
+            onClick={onWater}
+            aria-label="Water plant"
+            className={[
+              'flex h-10 w-10 items-center justify-center rounded-full',
+              'bg-blue-500 text-white shadow-md transition-transform',
+              'hover:-translate-y-1 focus:outline-none focus-visible:ring',
+            ].join(' ')}
+          >
+            <Droplet className="h-5 w-5" />
+          </button>
+          <button
+            onClick={onFertilize}
+            aria-label="Fertilize plant"
+            className={[
+              'flex h-10 w-10 items-center justify-center rounded-full',
+              'bg-green-500 text-white shadow-md transition-transform',
+              'hover:-translate-y-1 focus:outline-none focus-visible:ring',
+            ].join(' ')}
+          >
+            <Sprout className="h-5 w-5" />
+          </button>
+          <button
+            onClick={onAddNote}
+            aria-label="Add note to plant"
+            className={[
+              'flex h-10 w-10 items-center justify-center rounded-full',
+              'bg-purple-500 text-white shadow-md transition-transform',
+              'hover:-translate-y-1 focus:outline-none focus-visible:ring',
+            ].join(' ')}
+          >
+            <FileText className="h-5 w-5" />
+          </button>
+          <button
+            onClick={onEdit}
+            aria-label="Edit plant"
+            className={[
+              'flex h-10 w-10 items-center justify-center rounded-full',
+              'bg-orange-500 text-white shadow-md transition-transform',
+              'hover:-translate-y-1 focus:outline-none focus-visible:ring',
+            ].join(' ')}
+          >
+            <Edit className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- switch floating actions to a single FAB menu
- animate Water, Feed, Add Note, and Edit icons when menu opens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b658e851b08324ba87e964ba1b8151