### PR TITLE
Move health radar beside stress chart

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -24,6 +24,10 @@ const StressIndexChart = dynamic(
   () => import("@/components/Charts").then((m) => m.StressIndexChart),
   { ssr: false, loading: () => <p>Loading chart...</p> }
 )
+const PlantHealthRadar = dynamic(
+  () => import("@/components/Charts").then((m) => m.PlantHealthRadar),
+  { ssr: false, loading: () => <p>Loading chart...</p> }
+)
 const TaskCompletionChart = dynamic(
   () => import("@/components/Charts").then((m) => m.TaskCompletionChart),
   { ssr: false, loading: () => <p>Loading chart...</p> }
@@ -126,6 +130,8 @@ export default function SciencePanel() {
   })
   const stressData = stressTrend(stressReadings)
   const currentStress = stressData[stressData.length - 1]?.stress ?? 0
+  const plant = samplePlants["1"]
+  const currentWeather = weather[weather.length - 1]
 
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -203,9 +209,19 @@ export default function SciencePanel() {
 
       <section className="mt-4 md:mt-6">
         <h3 className="h3 text-gray-800">Plant Stress</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="mb-4">
           <StressIndexGauge value={currentStress} />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <StressIndexChart data={stressData} />
+          <PlantHealthRadar
+            hydration={plant.hydration}
+            lastFertilized={plant.lastFertilized}
+            nutrientLevel={plant.nutrientLevel ?? 100}
+            events={plant.events}
+            status={plant.status}
+            weather={currentWeather}
+          />
         </div>
       </section>
 

--- a/components/plant-detail/AnalyticsPanel.tsx
+++ b/components/plant-detail/AnalyticsPanel.tsx
@@ -113,9 +113,7 @@ export default function AnalyticsPanel({ plant, weather }: AnalyticsPanelProps) 
     {
       key: 'plant' as const,
       label: 'Plant Health',
-      content: (
-        <StressBlock plant={plant} weather={weather} stressData={stressData} />
-      ),
+      content: <StressBlock stressData={stressData} />,
     },
     {
       key: 'environment' as const,

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -4,25 +4,17 @@ import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import ChartCard from '@/components/ChartCard'
 import { type StressDatum } from '@/lib/plant-metrics'
-import type { Plant } from './types'
-import type { Weather } from '@/lib/weather'
 
-const PlantHealthRadar = dynamic(
-  () => import('@/components/Charts').then((m) => m.PlantHealthRadar),
-  { ssr: false, loading: () => <p>Loading chart...</p> }
-)
 const StressIndexChart = dynamic(
   () => import('@/components/Charts').then((m) => m.StressIndexChart),
   { ssr: false, loading: () => <p>Loading chart...</p> }
 )
 
 interface StressBlockProps {
-  plant: Plant
-  weather: Weather | null
   stressData: StressDatum[]
 }
 
-export default function StressBlock({ plant, weather, stressData }: StressBlockProps) {
+export default function StressBlock({ stressData }: StressBlockProps) {
   const [open, setOpen] = useState(false)
   return (
     <details id="plant-health" open={open}>
@@ -32,24 +24,10 @@ export default function StressBlock({ plant, weather, stressData }: StressBlockP
       >
         Plant Health
       </summary>
-      <p className="text-sm text-gray-500 mb-4">
-        Stress index overview and overall health radar.
-      </p>
-      <div className="flex gap-6 overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-visible">
-        <ChartCard title="Plant Health" insight="Overall health radar" variant="secondary">
-          <PlantHealthRadar
-            hydration={plant.hydration}
-            lastFertilized={plant.lastFertilized}
-            nutrientLevel={plant.nutrientLevel ?? 100}
-            events={plant.events}
-            status={plant.status}
-            weather={weather}
-          />
-        </ChartCard>
-        <ChartCard title="Stress Trend" insight="Stress trending down" variant="secondary">
-          <StressIndexChart data={stressData} />
-        </ChartCard>
-      </div>
+      <p className="text-sm text-gray-500 mb-4">Stress index overview.</p>
+      <ChartCard title="Stress Trend" insight="Stress trending down" variant="secondary">
+        <StressIndexChart data={stressData} />
+      </ChartCard>
     </details>
   )
 }


### PR DESCRIPTION
## Summary
- Remove PlantHealthRadar from plant health block
- Add PlantHealthRadar alongside stress chart in science panel
- Update analytics panel to use streamlined StressBlock

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b65d5c54a483248bc76e934de3459e