### PR TITLE
feat: handle empty stress chart

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -504,6 +504,14 @@ export interface StressIndexChartProps {
 }
 
 export function StressIndexChart({ data }: StressIndexChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[250px] w-full items-center justify-center text-sm text-gray-500">
+        No stress readings available
+      </div>
+    )
+  }
+
   const legendPayload = [
     { value: "Stress", type: "line", color: "#BD1212", id: "stress" },
     {

--- a/components/StressIndexChart.stories.tsx
+++ b/components/StressIndexChart.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { StressIndexChart } from "./Charts"
+import type { StressDatum } from "@/lib/plant-metrics"
+
+const sampleData: StressDatum[] = [
+  {
+    date: "2024-01-01",
+    stress: 20,
+    factors: { overdue: 5, hydration: 5, temperature: 5, light: 5 },
+  },
+  {
+    date: "2024-01-02",
+    stress: 40,
+    factors: { overdue: 10, hydration: 15, temperature: 5, light: 10 },
+  },
+  {
+    date: "2024-01-03",
+    stress: 60,
+    factors: { overdue: 15, hydration: 20, temperature: 10, light: 15 },
+  },
+]
+
+const meta = {
+  title: "Charts/StressIndexChart",
+  component: StressIndexChart,
+}
+export default meta
+
+export const Default = () => <StressIndexChart data={sampleData} />
+
+export const Empty = () => <StressIndexChart data={[]} />
+

--- a/components/__tests__/StressIndexChart.test.tsx
+++ b/components/__tests__/StressIndexChart.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { StressIndexChart } from '../Charts'
+
+jest.mock('recharts', () => {
+  const original = jest.requireActual('recharts')
+  const React = require('react')
+  return {
+    ...original,
+    ResponsiveContainer: ({ children }: any) => (
+      <div style={{ width: 400, height: 300 }}>
+        {React.cloneElement(children, { width: 400, height: 300 })}
+      </div>
+    ),
+  }
+})
+
+describe('StressIndexChart', () => {
+  it('renders fallback when data is empty', () => {
+    render(<StressIndexChart data={[]} />)
+    expect(
+      screen.getByText('No stress readings available')
+    ).toBeInTheDocument()
+  })
+})
+


### PR DESCRIPTION
## Summary
- show a friendly fallback when StressIndexChart receives no data
- add stories for default and empty stress data
- cover empty data case with a unit test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b704d7b98c8324bc69c83ded903edd