### PR TITLE
feat: toggle stress factor lines in stress chart

### DIFF
--- a/components/StressIndexChart.stories.tsx
+++ b/components/StressIndexChart.stories.tsx
@@ -26,7 +26,9 @@ const meta = {
 }
 export default meta
 
-export const Default = () => <StressIndexChart data={sampleData} />
+export const Default = () => (
+  <StressIndexChart data={sampleData} showFactors />
+)
 
 export const Empty = () => <StressIndexChart data={[]} />
 


### PR DESCRIPTION
## Summary
- plot individual stress factor lines and add UI toggles to show or hide them
- document optional `showFactors` prop for StressIndexChart
- update storybook example to demonstrate factor toggling

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72064b1a0832492eb0107530109e5