### PR TITLE
Expose stress factor breakdown and tooltip docs

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -76,7 +76,7 @@ function CustomTooltip({ active, payload, label }: any) {
   return null
 }
 
-interface StressTooltipProps {
+export interface StressTooltipProps {
   /** Whether the tooltip is active (provided by Recharts). */
   active?: boolean
   /** Data for the hovered point including factor scores. */
@@ -89,7 +89,7 @@ interface StressTooltipProps {
  * Tooltip for stress charts that displays each factor's contribution to the
  * overall stress index.
  */
-function StressTooltip({ active, payload, label }: StressTooltipProps) {
+export function StressTooltip({ active, payload, label }: StressTooltipProps) {
   if (active && payload?.length) {
     const datum = payload[0].payload
     const { overdue, hydration, temperature, light } = datum.factors

--- a/lib/plant-metrics.ts
+++ b/lib/plant-metrics.ts
@@ -141,7 +141,10 @@ export function calculateStressIndex({
   return Math.round(Math.max(0, Math.min(100, total)))
 }
 
-// Generate a series of stress index values for trend visualisation.
+/**
+ * Generate a stress trend series where each datum exposes the overall score
+ * and the individual factor contributions.
+ */
 export function stressTrend(
   readings: (StressInput & { date: string })[],
 ): StressDatum[] {


### PR DESCRIPTION
## Summary
- document stress trend helper to highlight per-factor scores
- export StressTooltip and its props for reuse

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7382c93408324afb36da474aa5789