### PR TITLE
feat: add stress moving average

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -97,6 +97,7 @@ export function StressTooltip({ active, payload, label }: StressTooltipProps) {
       <div className="rounded border bg-white p-2 shadow text-xs">
         <p className="font-medium">{label}</p>
         <p>Stress: {datum.stress}</p>
+        {datum.avg !== undefined && <p>Avg: {datum.avg}</p>}
         <p className="mt-1">Factors</p>
         <p>Overdue: {overdue}</p>
         <p>Hydration: {hydration}</p>
@@ -507,9 +508,15 @@ export interface StressIndexChartProps {
    * visibility.
    */
   showFactors?: boolean
+  /** When true, displays the rolling average stress line. */
+  showAverage?: boolean
 }
 
-export function StressIndexChart({ data, showFactors = false }: StressIndexChartProps) {
+export function StressIndexChart({
+  data,
+  showFactors = false,
+  showAverage = false,
+}: StressIndexChartProps) {
   const [visible, setVisible] = useState({
     overdue: true,
     hydration: true,
@@ -550,6 +557,9 @@ export function StressIndexChart({ data, showFactors = false }: StressIndexChart
 
   const legendPayload = [
     { value: "Stress", type: "line", color: "#BD1212", id: "stress" },
+    ...(showAverage
+      ? [{ value: "Avg", type: "line", color: "#2563EB", id: "avg" }]
+      : []),
     ...stressTiers.map((t) => ({
       value: t.label,
       type: "square",
@@ -635,6 +645,16 @@ export function StressIndexChart({ data, showFactors = false }: StressIndexChart
               stroke={factorColors.light}
               strokeWidth={2}
               name="Light"
+            />
+          )}
+          {showAverage && (
+            <Line
+              type="monotone"
+              dataKey="avg"
+              stroke="#2563EB"
+              strokeWidth={2}
+              dot={false}
+              name="Avg"
             />
           )}
           <Line

--- a/components/StressIndexChart.stories.tsx
+++ b/components/StressIndexChart.stories.tsx
@@ -6,16 +6,19 @@ const sampleData: StressDatum[] = [
   {
     date: "2024-01-01",
     stress: 20,
+    avg: 20,
     factors: { overdue: 5, hydration: 5, temperature: 5, light: 5 },
   },
   {
     date: "2024-01-02",
     stress: 40,
+    avg: 30,
     factors: { overdue: 10, hydration: 15, temperature: 5, light: 10 },
   },
   {
     date: "2024-01-03",
     stress: 60,
+    avg: 40,
     factors: { overdue: 15, hydration: 20, temperature: 10, light: 15 },
   },
 ]
@@ -31,6 +34,7 @@ export const Default: Story = {
   args: {
     data: sampleData,
     showFactors: true,
+    showAverage: true,
   },
 }
 

--- a/components/__tests__/StressIndexChart.test.tsx
+++ b/components/__tests__/StressIndexChart.test.tsx
@@ -21,5 +21,28 @@ describe('StressIndexChart', () => {
       screen.getByText('No stress readings available')
     ).toBeInTheDocument()
   })
+
+  it('optionally renders average line', () => {
+    const data = [
+      {
+        date: '2024-01-01',
+        stress: 20,
+        avg: 20,
+        factors: { overdue: 5, hydration: 5, temperature: 5, light: 5 },
+      },
+      {
+        date: '2024-01-02',
+        stress: 40,
+        avg: 30,
+        factors: { overdue: 10, hydration: 15, temperature: 5, light: 10 },
+      },
+    ]
+    const { rerender } = render(
+      <StressIndexChart data={data} showAverage={false} />,
+    )
+    expect(screen.queryByText('Avg')).not.toBeInTheDocument()
+    rerender(<StressIndexChart data={data} showAverage />)
+    expect(screen.getByText('Avg')).toBeInTheDocument()
+  })
 })
 

--- a/lib/__tests__/plant-metrics.test.ts
+++ b/lib/__tests__/plant-metrics.test.ts
@@ -5,6 +5,7 @@ import {
   WaterEvent,
   calculateHydrationTrend,
   collectPlantMetrics,
+  stressTrend,
 } from '../plant-metrics'
 import { samplePlants } from '../plants'
 
@@ -37,5 +38,34 @@ describe('plant metrics', () => {
     const metrics = collectPlantMetrics(plants)
     expect(metrics[0]).toMatchObject({ date: '2024-08-21', Delilah: 80 })
     expect(metrics.some((m) => m.Sunny === 92)).toBe(true)
+  })
+
+  it('computes stress trend with moving average', () => {
+    const readings = [
+      {
+        date: '2024-01-01',
+        overdueDays: 0,
+        hydration: 100,
+        temperature: 25,
+        light: 50,
+      },
+      {
+        date: '2024-01-02',
+        overdueDays: 1,
+        hydration: 80,
+        temperature: 25,
+        light: 50,
+      },
+      {
+        date: '2024-01-03',
+        overdueDays: 2,
+        hydration: 60,
+        temperature: 25,
+        light: 50,
+      },
+    ]
+    const trend = stressTrend(readings, 2)
+    expect(trend[1].avg).toBeCloseTo((trend[0].stress + trend[1].stress) / 2)
+    expect(trend[2].avg).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary
- calculate moving average of stress readings
- toggleable average line for stress index chart
- cover moving average in tests

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b73c00f3f483248d5e61ed1f1b6383