### PR TITLE
feat: add stress chart event markers

### DIFF
--- a/components/StressIndexChart.stories.tsx
+++ b/components/StressIndexChart.stories.tsx
@@ -20,6 +20,11 @@ const sampleData: StressDatum[] = [
   },
 ]
 
+const sampleEvents = [
+  { date: "2024-01-02", type: "water" },
+  { date: "2024-01-03", type: "fertilize" },
+]
+
 const meta: Meta<typeof StressIndexChart> = {
   title: "Charts/StressIndexChart",
   component: StressIndexChart,
@@ -30,6 +35,7 @@ type Story = StoryObj<typeof StressIndexChart>
 export const Default: Story = {
   args: {
     data: sampleData,
+    events: sampleEvents,
     showFactors: true,
   },
 }

--- a/components/__tests__/StressIndexChart.test.tsx
+++ b/components/__tests__/StressIndexChart.test.tsx
@@ -21,5 +21,24 @@ describe('StressIndexChart', () => {
       screen.getByText('No stress readings available')
     ).toBeInTheDocument()
   })
+
+  it('shows event legend entries', () => {
+    const data = [
+      {
+        date: '2024-01-01',
+        stress: 20,
+        factors: { overdue: 5, hydration: 5, temperature: 5, light: 5 },
+      },
+      {
+        date: '2024-01-02',
+        stress: 40,
+        factors: { overdue: 10, hydration: 15, temperature: 5, light: 10 },
+      },
+    ]
+    render(
+      <StressIndexChart data={data} events={[{ date: '2024-01-02', type: 'water' }]} />
+    )
+    expect(screen.getByText(/water/i)).toBeInTheDocument()
+  })
 })
 


### PR DESCRIPTION
## Summary
- accept optional events in StressIndexChart
- draw event icons along stress line with a scatter overlay
- document usage in story and add tests/tooltip legend support

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b73db9e48c83248543344f51bf7373