### PR TITLE
feat: visualize stress events

### DIFF
--- a/components/StressIndexChart.stories.tsx
+++ b/components/StressIndexChart.stories.tsx
@@ -23,6 +23,11 @@ const sampleData: StressDatum[] = [
   },
 ]
 
+const sampleEvents = [
+  { date: "2024-01-02", type: "Watered" },
+  { date: "2024-01-03", type: "Fertilized" },
+]
+
 const meta: Meta<typeof StressIndexChart> = {
   title: "Charts/StressIndexChart",
   component: StressIndexChart,
@@ -35,6 +40,7 @@ export const Default: Story = {
     data: sampleData,
     showFactors: true,
     showAverage: true,
+    events: sampleEvents,
   },
 }
 

--- a/components/__tests__/StressIndexChart.test.tsx
+++ b/components/__tests__/StressIndexChart.test.tsx
@@ -44,5 +44,23 @@ describe('StressIndexChart', () => {
     rerender(<StressIndexChart data={data} showAverage />)
     expect(screen.getByText('Avg')).toBeInTheDocument()
   })
+
+  it('shows legend entry for events', () => {
+    const data = [
+      {
+        date: '2024-01-01',
+        stress: 20,
+        factors: { overdue: 5, hydration: 5, temperature: 5, light: 5 },
+      },
+      {
+        date: '2024-01-02',
+        stress: 40,
+        factors: { overdue: 10, hydration: 15, temperature: 5, light: 10 },
+      },
+    ]
+    const events = [{ date: '2024-01-02', type: 'Watered' }]
+    render(<StressIndexChart data={data} events={events} />)
+    expect(screen.getByText('Event')).toBeInTheDocument()
+  })
 })
 


### PR DESCRIPTION
## Summary
- allow StressIndexChart to accept `events` and render markers along the stress line
- surface event details in tooltips and legend
- cover event markers in Storybook and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b73ee3f380832487d3dafa04deb6b7