### PR TITLE
feat: add stress chart help modal

### DIFF
--- a/app/(dashboard)/science/page.tsx
+++ b/app/(dashboard)/science/page.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react"
 import dynamic from "next/dynamic"
 import { useRouter, useSearchParams } from "next/navigation"
+import { HelpCircle } from "lucide-react"
+import Modal from "@/components/Modal"
+import { StressHelpContent } from "@/components/Charts"
 
 const TempHumidityChart = dynamic(
   () => import("@/components/Charts").then((m) => m.TempHumidityChart),
@@ -52,6 +55,7 @@ export default function SciencePanel() {
   const readings = { temperature: 75, humidity: 52, vpd: 1.2 }
   const [tempUnit, setTempUnit] = useState<"F" | "C">("F")
   const [wateringInterval, setWateringInterval] = useState(7)
+  const [showHelp, setShowHelp] = useState(false)
 
   const weather: WeatherDay[] = [
     {
@@ -208,7 +212,17 @@ export default function SciencePanel() {
       </section>
 
       <section className="mt-4 md:mt-6">
-        <h3 className="h3 text-gray-800">Plant Stress</h3>
+        <div className="mb-2 flex items-center gap-1">
+          <h3 className="h3 text-gray-800 flex-1">Plant Stress</h3>
+          <button
+            type="button"
+            onClick={() => setShowHelp(true)}
+            aria-label="Help"
+            className="text-gray-500 hover:text-gray-700"
+          >
+            <HelpCircle className="h-4 w-4" />
+          </button>
+        </div>
         <div className="mb-4">
           <StressIndexGauge value={currentStress} />
         </div>
@@ -252,6 +266,9 @@ export default function SciencePanel() {
       </section>
 
       <Footer />
+      <Modal isOpen={showHelp} onClose={() => setShowHelp(false)}>
+        <StressHelpContent />
+      </Modal>
     </main>
   )
 }

--- a/components/ChartCard.tsx
+++ b/components/ChartCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { HelpCircle } from 'lucide-react'
 
 interface ChartCardProps {
   title: string
   insight: string
   children: ReactNode
   variant?: 'primary' | 'secondary'
+  onHelp?: () => void
 }
 
 export default function ChartCard({
@@ -14,6 +16,7 @@ export default function ChartCard({
   insight,
   children,
   variant = 'secondary',
+  onHelp,
 }: ChartCardProps) {
   const base = 'snap-start rounded-lg p-4 border shadow-sm'
   const variantClasses =
@@ -23,7 +26,19 @@ export default function ChartCard({
 
   return (
     <div className={`${base} ${variantClasses}`}>
-      <h4 className="h4 font-semibold mb-2 text-gray-900 dark:text-gray-100">{title}</h4>
+      <div className="mb-2 flex items-center gap-1">
+        <h4 className="h4 font-semibold flex-1 text-gray-900 dark:text-gray-100">{title}</h4>
+        {onHelp && (
+          <button
+            type="button"
+            onClick={onHelp}
+            aria-label="Help"
+            className="text-gray-500 hover:text-gray-700"
+          >
+            <HelpCircle className="h-4 w-4" />
+          </button>
+        )}
+      </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{insight}</p>
       {children}
     </div>

--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -43,6 +43,44 @@ import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { useState } from "react"
 
+/**
+ * Content describing how the stress index is calculated along with mitigation tips.
+ * This can be rendered inside a modal or tooltip when users request help.
+ */
+export function StressHelpContent() {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold mb-2">Stress Index Guide</h3>
+      <p className="mb-2">
+        The stress index combines several factors into a 0–100 score. Lower values mean a healthier plant.
+      </p>
+      <ul className="list-disc pl-5 mb-2 text-sm">
+        <li>Overdue watering: up to 30 points</li>
+        <li>Low hydration: up to 40 points</li>
+        <li>Temperature deviation: up to 15 points</li>
+        <li>Light imbalance: up to 15 points</li>
+      </ul>
+      <p className="mb-2 text-sm">
+        Keep a consistent care schedule, adjust lighting, and maintain stable temperatures to reduce stress.
+      </p>
+      <p className="text-sm">
+        <Link href="/docs/stress-index" className="text-blue-600 underline" target="_blank" rel="noreferrer">
+          Full stress documentation
+        </Link>
+        {' '}|
+        <a
+          href="https://en.wikipedia.org/wiki/Plant_stress"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 underline"
+        >
+          Plant stress overview
+        </a>
+      </p>
+    </div>
+  )
+}
+
 
 // Dummy dataset for environment over 7 days
 const defaultEnvData = [

--- a/components/plant-detail/StressBlock.tsx
+++ b/components/plant-detail/StressBlock.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import ChartCard from '@/components/ChartCard'
+import Modal from '@/components/Modal'
+import { StressHelpContent } from '@/components/Charts'
 import { type StressDatum } from '@/lib/plant-metrics'
 
 const StressIndexChart = dynamic(
@@ -16,19 +18,30 @@ interface StressBlockProps {
 
 export default function StressBlock({ stressData }: StressBlockProps) {
   const [open, setOpen] = useState(false)
+  const [showHelp, setShowHelp] = useState(false)
   return (
-    <details id="plant-health" open={open}>
-      <summary
-        className="flex items-center gap-1 text-lg font-semibold cursor-pointer py-2 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2"
-        onClick={() => setOpen((o) => !o)}
-      >
-        Plant Health
-      </summary>
-      <p className="text-sm text-gray-500 mb-4">Stress index overview.</p>
-      <ChartCard title="Stress Trend" insight="Stress trending down" variant="secondary">
-        <StressIndexChart data={stressData} />
-      </ChartCard>
-    </details>
+    <>
+      <details id="plant-health" open={open}>
+        <summary
+          className="flex items-center gap-1 text-lg font-semibold cursor-pointer py-2 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2"
+          onClick={() => setOpen((o) => !o)}
+        >
+          Plant Health
+        </summary>
+        <p className="text-sm text-gray-500 mb-4">Stress index overview.</p>
+        <ChartCard
+          title="Stress Trend"
+          insight="Stress trending down"
+          variant="secondary"
+          onHelp={() => setShowHelp(true)}
+        >
+          <StressIndexChart data={stressData} />
+        </ChartCard>
+      </details>
+      <Modal isOpen={showHelp} onClose={() => setShowHelp(false)}>
+        <StressHelpContent />
+      </Modal>
+    </>
   )
 }
 

--- a/docs/stress-index.md
+++ b/docs/stress-index.md
@@ -1,0 +1,18 @@
+# Stress Index
+
+The stress index combines several plant health factors into a single 0-100 score.
+Lower values indicate a healthier plant.
+
+## Formula
+- **Overdue watering** – up to 30 points (each overdue day adds 10).
+- **Low hydration** – up to 40 points (0% moisture = 40 points).
+- **Temperature deviation** – up to 15 points (1.5 points per °C from 25°C).
+- **Light imbalance** – up to 15 points (0.3 points per unit from ideal 50).
+
+## Mitigation Tips
+- Maintain a regular watering schedule.
+- Monitor soil moisture and adjust watering to keep hydration between 40-80%.
+- Keep plants near stable, appropriate temperatures.
+- Adjust lighting or move plants to achieve balanced light exposure.
+
+For more general advice, see the [Plant stress overview](https://en.wikipedia.org/wiki/Plant_stress).


### PR DESCRIPTION
## Summary
- add optional help icon to ChartCard and stress sections
- document stress index formula and mitigation tips

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b77a7252088324944b7b6e702c8186